### PR TITLE
IT-377 Update SynapseExternalBucket.yaml

### DIFF
--- a/templates/SynapseExternalBucket.yaml
+++ b/templates/SynapseExternalBucket.yaml
@@ -10,11 +10,11 @@ Parameters:
     Default: false
   EncryptBucket:
     Type: String
-    Description: true to encrypt bucket, false (default) for no encryption
+    Description: true (default) to encrypt bucket, false for no encryption
     AllowedValues:
       - true
       - false
-    Default: false
+    Default: true
   BucketVersioning:
     Type: String
     Description: Enabled to enable bucket versionsing, default is Suspended


### PR DESCRIPTION
This changes the default bucket encryption from false to true to reduce the chance that someone will place HIPAA-affected data into a bucket unencrypted by mistake.  Our tests show virtually no performance impact of encrypting files at rest.