### PR TITLE
Allow access to public EC2 instances with an SSH keypair

### DIFF
--- a/templates/managed-ec2.yaml
+++ b/templates/managed-ec2.yaml
@@ -487,6 +487,8 @@ Resources:
           GroupSet:
             - !ImportValue
               'Fn::Sub': '${AWS::Region}-${VpcName}-VpnSecurityGroup'
+            - !ImportValue
+              'Fn::Sub': '${AWS::Region}-${VpcName}-BastianSecurityGroup'
           SubnetId: !ImportValue
             'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'
       UserData: !Base64


### PR DESCRIPTION
Allow SSH access to public and private EC2 instances.  This will allow
users to access public instances from with an SSH keypair.
This does not affect private instances because they are still deployed
to a private subnet.  Private instances are still only accessible
after logging into the Sage VPN.