### PR TITLE
move Bruce's bucket config from scicomp-infra to scicomp-provisioner

### DIFF
--- a/config/prod/AMP-WGS-MSSM-Transfer.yaml
+++ b/config/prod/AMP-WGS-MSSM-Transfer.yaml
@@ -1,0 +1,18 @@
+# Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
+template_path: templates/SynapseExternalBucket.yaml
+stack_name: AMP-WGS-MSSM-Transfer
+parameters:
+  # true for read-write bucket, false (default) for read-only bucket 
+  AllowWriteBucket: "true"
+  # Synapse username
+  SynapseUserName: "brucehoff"
+  # true to encrypt bucket, false (default) for no encryption
+  EncryptBucket: "true"
+  # Bucket owner's email address
+  OwnerEmail: bruce.hoff@sagebase.org
+
+  # true to restrict bucket GetObject access to only AWS resources on the same region as the bucket
+  SameRegionResourceAccessToBucket: 'true'
+hooks:
+  after_create:
+    - !synapse_external_bucket


### PR DESCRIPTION
The https://github.com/Sage-Bionetworks/scicomp-infra/pull/123 and https://github.com/Sage-Bionetworks/scicomp-infra/pull/158 pull request got lost when we moved from scicomp-infra to scicomp-provisioner. 

Also added `SameRegionResourceAccessToBucket: 'true'` to restrict download access from the bucket