### PR TITLE
Fix access to public EC2 intances

### DIFF
--- a/config/prod/test-AMP-Emory-ec2.yaml
+++ b/config/prod/test-AMP-Emory-ec2.yaml
@@ -1,5 +1,5 @@
 # Provision an EC2 instance
-template_path: templates/managed-ec2.yaml
+template_path: templates/managed-ec2-v2.yaml
 stack_name: test-AMP-Emory-ec2
 parameters:
   # The Sage deparment for this resource

--- a/templates/managed-ec2-v2.yaml
+++ b/templates/managed-ec2-v2.yaml
@@ -1,7 +1,3 @@
-#######################################################
-# THIS TEMPLATE IS DEPRECATED
-# PLEASE USE managed-ec2-v2.yaml
-#######################################################
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Provision EC2 instance, connect to Jumpcloud, and associate with a jumpcloud systems group.
@@ -491,6 +487,8 @@ Resources:
           GroupSet:
             - !ImportValue
               'Fn::Sub': '${AWS::Region}-${VpcName}-VpnSecurityGroup'
+            - !ImportValue
+              'Fn::Sub': '${AWS::Region}-${VpcName}-BastianSecurityGroup'
           SubnetId: !ImportValue
             'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'
       UserData: !Base64


### PR DESCRIPTION
Allow SSH access to public and private EC2 instances. This will allow
users to access public instances using a valid SSH keypair.
This does not affect private instances because they are still deployed
to a private subnet. Private instances are still only accessible
after logging into the Sage VPN.

Note: We cannot add this change to the current template because
cloudformation will want to terminate existing instances and
create new ones.  This will blow away existing intances that
people have already provisioned.  To work around this issue
we need to rev the template version and deprecate the existing
one.