### PR TITLE
[IT-433] tag for park my cloud

### DIFF
--- a/templates/managed-ec2-v4.yaml
+++ b/templates/managed-ec2-v4.yaml
@@ -1,7 +1,3 @@
-#######################################################
-# THIS TEMPLATE IS DEPRECATED
-# PLEASE USE managed-ec2-v4.yaml
-#######################################################
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Provision EC2 instance, connect to Jumpcloud, and associate with a jumpcloud systems group.
@@ -124,6 +120,10 @@ Parameters:
   OwnerEmail:
     Description: The owner's email address for this resource (i.e. jsmith@sagebase.org)
     Type: String
+  ParkMyCloudManaged:
+    Description: Allow ParkMyCloud service to start/stop resources
+    Type: String
+    Default: 'yes'
   AMIId:
     Description: ID of the AMI to deploy
     Type: String
@@ -433,6 +433,8 @@ Resources:
             - !Ref 'AWS::Region'
             - |+
       Tags:
+        - Key: "parkmycloud"
+          Value: !Ref ParkMyCloudManaged
         - Key: "Name"
           Value: !Ref 'AWS::StackName'
         - Key: "Department"


### PR DESCRIPTION
The policy[1] that we use to integrate with ParkMyCloud[2]
requires a parkmycloud=yes tag to allow the service
to start and stop any resources on AWS.

[1] https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/ParkMyCloud.yaml#L74
[2] https://www.parkmycloud.com