### PR TITLE
update template for new linter rules

### DIFF
--- a/templates/managed-ec2-v3.yaml
+++ b/templates/managed-ec2-v3.yaml
@@ -80,11 +80,9 @@ Parameters:
       - d2.2xlarge
       - d2.4xlarge
       - d2.8xlarge
-      - hi1.4xlarge
       - hs1.8xlarge
       - cr1.8xlarge
       - cc2.8xlarge
-      - cg1.4xlarge
     ConstraintDescription: must be a valid EC2 instance type.
   JcConnectKey:
     Description: Connection key used to let JC agent connect to a Jumpcloud account.
@@ -266,8 +264,6 @@ Mappings:
     d2.4xlarge:
       Arch: HVM64
     d2.8xlarge:
-      Arch: HVM64
-    hi1.4xlarge:
       Arch: HVM64
     hs1.8xlarge:
       Arch: HVM64

--- a/templates/managed-ec2-v4.yaml
+++ b/templates/managed-ec2-v4.yaml
@@ -76,11 +76,9 @@ Parameters:
       - d2.2xlarge
       - d2.4xlarge
       - d2.8xlarge
-      - hi1.4xlarge
       - hs1.8xlarge
       - cr1.8xlarge
       - cc2.8xlarge
-      - cg1.4xlarge
     ConstraintDescription: must be a valid EC2 instance type.
   JcConnectKey:
     Description: Connection key used to let JC agent connect to a Jumpcloud account.
@@ -266,8 +264,6 @@ Mappings:
     d2.4xlarge:
       Arch: HVM64
     d2.8xlarge:
-      Arch: HVM64
-    hi1.4xlarge:
       Arch: HVM64
     hs1.8xlarge:
       Arch: HVM64

--- a/templates/managed-ec2.yaml
+++ b/templates/managed-ec2.yaml
@@ -73,11 +73,9 @@ Parameters:
       - d2.2xlarge
       - d2.4xlarge
       - d2.8xlarge
-      - hi1.4xlarge
       - hs1.8xlarge
       - cr1.8xlarge
       - cc2.8xlarge
-      - cg1.4xlarge
     ConstraintDescription: must be a valid EC2 instance type.
   JcConnectKey:
     Description: Connection key used to let JC agent connect to a Jumpcloud account.
@@ -239,8 +237,6 @@ Mappings:
     d2.4xlarge:
       Arch: HVM64
     d2.8xlarge:
-      Arch: HVM64
-    hi1.4xlarge:
       Arch: HVM64
     hs1.8xlarge:
       Arch: HVM64


### PR DESCRIPTION
New AWS cloudformation linter rules don't like hi1.4xlarge
and cg1.4xlarge instance types. I'm not sure why but we
can remove them to satisfy the linter because we don't use them.