### PR TITLE
Example PR: auto provision a S3 static website

### DIFF
--- a/config/prod/iwanna-website.yaml
+++ b/config/prod/iwanna-website.yaml
@@ -1,0 +1,23 @@
+# Provision a static website with S3 bucket and cloudfront (HTTP and HTTPS)
+template_path: remote/managed-s3WebCloudfront.yaml
+stack_name: iwanna-website
+parameters:
+  # The Sage deparment for this resource
+  Department: "Platform"
+  # The Sage project this resource will be used for
+  Project: "Infrastructure"
+  # The resource owner
+  OwnerEmail: "joe.smith@sagebase.org"
+  # The website domain name (i.e. sagebionetworks.org)
+  DomainName: "sagebionetworks.org"
+  # The website sub domain name (i.e. 'mysite' in mysite.sagebionetworks.org)
+  SubDomainName: "mysite"
+  # The SSL certificate from the AWS Certificate Manager (ask IT for one).
+  AcmCertificateArn: "arn:aws:acm:us-east-1:111111111111:certificate/12e131f3-f411-111f-b574-1d6316b8901a"
+
+# For CI system (do not change)
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/master/managed-s3WebCloudfront.yaml --create-dirs -o templates/remote/managed-s3WebCloudfront.yaml"
+  after_create:
+    - !s3_web_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
This is an example PR (do not merge!). It is a template to show
how to get the CI system to automatically provision a static website
with an S3 bucket and cloudfront.  The website will be accessible
with http and https.

Instance creation workflow:

* Scientist work with IT to determine if this setup is appropriate
  for their use case.
* (Optional) Register a domain. Not needed if using sagebase.org and sagebionetworks.org
* (Optional) Request a SSL certificate (only required for https).  Ask IT for one.
* Scientist create a PR similar to this one. Create a new file
with a unique stack_name and updated parameters.
* Have someone review and approve the PR.
* Merge the PR
* The CI system will auto provision the resources
* An email will be sent to the owner email address with website endpoint.
* The newly created resources will contain tags similear to these:

```
key: Department
value: Platform

key: OwnerEmail
value: joe.smith@sagebase.org

key: Project
value: Infrastructure

```

To remove the resources:

* Instance owner must create a new PR that deletes the files that was added by
the PR that was used to add the instance.
* Have an an AWS account Admin review your change.
* Approve and merge.