### PR TITLE
add c5 instance types

### DIFF
--- a/templates/managed-ec2-v4.yaml
+++ b/templates/managed-ec2-v4.yaml
@@ -61,6 +61,12 @@ Parameters:
       - c4.2xlarge
       - c4.4xlarge
       - c4.8xlarge
+      - c5.large
+      - c5.xlarge
+      - c5.2xlarge
+      - c5.4xlarge
+      - c5.9xlarge
+      - c5.18xlarge
       - g2.2xlarge
       - g2.8xlarge
       - r3.large
@@ -234,6 +240,18 @@ Mappings:
     c4.4xlarge:
       Arch: HVM64
     c4.8xlarge:
+      Arch: HVM64
+    c5.large:
+      Arch: HVM64
+    c5.xlarge:
+      Arch: HVM64
+    c5.2xlarge:
+      Arch: HVM64
+    c5.4xlarge:
+      Arch: HVM64
+    c5.9xlarge:
+      Arch: HVM64
+    c5.18xlarge:
       Arch: HVM64
     g2.2xlarge:
       Arch: HVMG2


### PR DESCRIPTION
c5 has already been enabled on sandbox ec2 template this is
to enable in scicomp as well.