### PR TITLE
Option to grant access to bucket

### DIFF
--- a/config/prod/amp-emory-bucket.yaml
+++ b/config/prod/amp-emory-bucket.yaml
@@ -1,7 +1,11 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
-template_path: SynapseExternalBucket.yaml
+template_path: SynapseExternalBucket-v2.yaml
 stack_name: AMP-Emory-Bucket
 parameters:
+  # The Sage deparment for this resource
+  Department: "SysBio"
+  # The Sage project this resource will be used for
+  Project: "AMP-Emory"
   # true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
   # Synapse username
@@ -9,7 +13,12 @@ parameters:
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "true"
   # Bucket owner's email address
-  OwnerEmail: ampadportal@sagebase.org
+  OwnerEmail: 'ampadportal@sagebase.org'
+  # Allow accounts, groups, and users to access bucket.
+  GrantAccess:
+    - 'arn:aws:iam::325565585839:root'
+    - 'arn:aws:iam::743849566882:user/dduong'
+    - 'arn:aws:iam::563295687221:user/phil.snyder@sagebase.org'
 hooks:
   after_create:
     - !synapse_bucket_notify {{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}

--- a/config/prod/gates-ki-001-s3bucket.yaml
+++ b/config/prod/gates-ki-001-s3bucket.yaml
@@ -1,7 +1,11 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
-template_path: SynapseExternalBucket.yaml
+template_path: SynapseExternalBucket-v2.yaml
 stack_name: gates-ki-001
 parameters:
+  # The Sage deparment for this resource
+  Department: "SysBio"
+  # The Sage project this resource will be used for
+  Project: "GatesKi"
   # true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
   # Synapse username
@@ -9,7 +13,10 @@ parameters:
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "true"
   # Bucket owner's email address
-  OwnerEmail: kenneth.daily@sagebase.org
+  OwnerEmail: 'kenneth.daily@sagebase.org'
+  # Allow accounts, groups, and users to access bucket.
+  GrantAccess:
+    - 'arn:aws:iam::325565585839:root'
 hooks:
   after_create:
     - !synapse_bucket_notify {{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}

--- a/templates/SynapseExternalBucket-v2.yaml
+++ b/templates/SynapseExternalBucket-v2.yaml
@@ -45,6 +45,11 @@ Parameters:
   OwnerEmail:
     Type: String
     Description: The bucket owner's email address
+  GrantAccess:
+    Type: CommaDelimitedList
+    Default: "[]"
+    Description: Grant bucket access to accounts, groups, and users.
+    ConstraintDescription: List of ARNs (i.e. [arn:aws:iam::011223344556:user/jsmith, arn:aws:iam::544332211006:user/rjones']
   EnableDataLifeCycle:
     Type: String
     Description: Enabled to enable bucket lifecycle rule, default is Disabled
@@ -70,6 +75,7 @@ Parameters:
     Default: 365000
 Conditions:
   AllowWrite: !Equals [!Ref AllowWriteBucket, true]
+  AllowUserAccess: !Not [!Equals [!Join ['', !Ref GrantAccess], "[]"]]
   EnableEncryption: !Equals [!Ref EncryptBucket, true]
   DisableEncryption: !Not [!Condition EnableEncryption]
   CreateIPAddressRestrictionLambda: !Equals [!Ref SameRegionResourceAccessToBucket, true]
@@ -141,6 +147,7 @@ Resources:
 
   ExternalBucketPolicy:
     Type: "AWS::S3::BucketPolicy"
+    Condition: AllowUserAccess
     Properties:
       Bucket: !If [EnableEncryption, !Ref SynapseEncryptedExternalBucket, !Ref SynapseExternalBucket]
       PolicyDocument:
@@ -150,14 +157,14 @@ Resources:
             Sid: "ReadAccess"
             Effect: "Allow"
             Principal:
-              AWS: "325565585839"
+              AWS: !Ref GrantAccess
             Action: "s3:ListBucket*"
             Resource: !If [EnableEncryption, !GetAtt SynapseEncryptedExternalBucket.Arn, !GetAtt SynapseExternalBucket.Arn]
           -
             Sid: "WriteAccess"
             Effect: "Allow"
             Principal:
-              AWS: "325565585839"
+              AWS: !Ref GrantAccess
             Action:
               - !If [AllowWrite, "s3:*Object*", "s3:GetObject*"]
               - "s3:*MultipartUpload*"


### PR DESCRIPTION
This is to setup cross account access[1]. Add a parameter to
allow the provisioner to specify which account, group and user
can have access to the provisioned bucket. It is not a required
parameter, if nothing is specified then no access will be given.

[1] https://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example2.html