### PR TITLE
give service account access to bucket

### DIFF
--- a/config/prod/AMP-Mayo-Sinai-Bucket.yaml
+++ b/config/prod/AMP-Mayo-Sinai-Bucket.yaml
@@ -20,6 +20,8 @@ parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:iam::563295687221:user/william.poehlman@sagebase.org'
+    - 'arn:aws:iam::563295687221:user/khai.do@sagebase.org'
+    - 'arn:aws:iam::563295687221:user/bootstrap-AWSIAMTravisUser-BP6FVD6SZZCN'
 
 # For CI system (do not change)
 hooks:


### PR DESCRIPTION
Service account needs access to migrate MSSM bucket data.