### PR TITLE
Recreate new windows AMI

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,5 +11,5 @@ aws_account_email: aws.scicomp@sagebase.org
 default_ami: "ami-082278746f893d99c"
 default_key_pair: "scicomp"
 default_vpc: "computevpc"
-default_win_ami: "ami-0e50f04c1dab2eb7e"
+default_win_ami: "ami-0388ce15d3f7066cb"
 


### PR DESCRIPTION
Creating Windows AMIs requires additional prep.  Had to recreate
the default windows AMI with Sysprep[1]

[1] https://aws.amazon.com/premiumsupport/knowledge-center/sysprep-create-install-ec2-windows-amis/