### PR TITLE
Update default ubuntu AMI

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,5 +12,5 @@ default_ami: "ami-082278746f893d99c"
 default_key_pair: "scicomp"
 default_vpc: "computevpc"
 default_win_ami: "ami-0388ce15d3f7066cb"
-default_ubuntu_ami: "ami-06ae50b5661319711"
+default_ubuntu_ami: "ami-0618d7bfcc5a707aa"
 


### PR DESCRIPTION
The provisioner failed to provision Ubuntu instances with the current
default ubuntu AMI.  Created a new ubuntu AMI with an encrypted root
volume based off of ami-0a313d6098716f372.  We switch to this new
one to provision ubuntu instances.