### PR TITLE
Provision RStudio environment to use for miniDREAM course

### DIFF
--- a/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
+++ b/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
@@ -1,24 +1,46 @@
 # Provision an EC2 instance
-template_path: managed-ec2-v7.yaml
+template_path: remote/managed-ec2.yaml
 stack_name: minidream-R-env-pub-prod-instance-ec2 
 parameters:
-  # The Sage deparment for this resource
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
   Department: "Computational Oncology"
   # The Sage project this resource will be used for
   Project: "CSBC"
-  # The resource owner
   OwnerEmail: "milen.nikolov@sagebase.org"
-  AMIId: "ami-084302eb33c52749d"
-  # EC2 instance type (available types https://aws.amazon.com/ec2/instance-types/)
+
+  # Default account settings, leave alone unless you plan to override
+  VpcName: "{{stack_group_config.default_vpc}}"
+  KeyName: "{{stack_group_config.default_key_pair}}"
+  AMIId: "{{stack_group_config.default_ami}}"
+
+  # Settings have default values but can be overriden. Set the below
+  # parameters *only* if you want to override the defaults.
+
+  # (Optional) EC2 instance type, default is "t2.nano" (other available types https://aws.amazon.com/ec2/instance-types/)
   InstanceType: "r4.16xlarge"
+  # (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
+  VolumeSize: "500"
+  # (Optional) Base instance on AMI (default: ami-082278746f893d99c) (supported distros: AWS linux)
+  # AMIId: "ami-0de53d8956e8dcf80"
+  # (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
   VpcSubnet: "PublicSubnet"
-  # (Optional) Expose a port to incoming traffic (valid range: 1-65535)
+  # (Optional) Expose a port to incoming traffic (default is no open ports) (valid range: 1-65535)
   OpenPort: "8787"
+  # (Optional) Set true to enable daily backups (default: false)
+  BackupEc2: "true"
+  # (Optional) Number of daily backups to keep (default: 7) (valid range: 1-180)
+  SnapshotCount: "3"
 
   # Integration with our jumpcloud directory service (do not change)
   JcConnectKey: !ssm /infra/JcConnectKey
   JcServiceApiKey: !ssm /infra/JcServiceApiKey
   JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
+# For CI system (do not change)
 hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"
+

--- a/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
+++ b/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
@@ -1,0 +1,24 @@
+# Provision an EC2 instance
+template_path: managed-ec2-v5.yaml
+stack_name: minidream-R-env-pub-prod-instance-ec2 
+parameters:
+  # The Sage deparment for this resource
+  Department: "Computational Oncology"
+  # The Sage project this resource will be used for
+  Project: "CSBC"
+  # The resource owner
+  OwnerEmail: "milen.nikolov@sagebase.org"
+  AMIId: "ami-084302eb33c52749d"
+  # EC2 instance type (available types https://aws.amazon.com/ec2/instance-types/)
+  InstanceType: "r4.16xlarge"
+  VpcSubnet: "PublicSubnet"
+  # (Optional) Expose a port to incoming traffic (valid range: 1-65535)
+  OpenPort: "8787"
+
+  # Integration with our jumpcloud directory service (do not change)
+  JcConnectKey: !ssm /infra/JcConnectKey
+  JcServiceApiKey: !ssm /infra/JcServiceApiKey
+  JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
+hooks:
+  after_create:
+    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
+++ b/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
@@ -1,5 +1,5 @@
 # Provision an EC2 instance
-template_path: managed-ec2-v5.yaml
+template_path: managed-ec2-v7.yaml
 stack_name: minidream-R-env-pub-prod-instance-ec2 
 parameters:
   # The Sage deparment for this resource

--- a/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
+++ b/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
@@ -23,9 +23,9 @@ parameters:
   # (Optional) Base instance on AMI (default: ami-082278746f893d99c) (supported distros: AWS linux)
   # AMIId: "ami-0de53d8956e8dcf80"
   # (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
-  VpcSubnet: "PublicSubnet"
+  #VpcSubnet: "PublicSubnet"
   # (Optional) Expose a port to incoming traffic (default is no open ports) (valid range: 1-65535)
-  OpenPort: "8787"
+  #OpenPort: "8787"
   # (Optional) Set true to enable daily backups (default: false)
   BackupEc2: "true"
   # (Optional) Number of daily backups to keep (default: 7) (valid range: 1-180)

--- a/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
+++ b/config/prod/minidream-R-env-pub-prod-instance-ec2.yaml
@@ -1,9 +1,9 @@
 # Provision an EC2 instance
 template_path: remote/managed-ec2.yaml
-stack_name: minidream-R-env-pub-prod-instance-ec2 
+stack_name: minidream-R-env-pub-prod-instance-ec2
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "Computational Oncology"
+  Department: "CompOnc"
   # The Sage project this resource will be used for
   Project: "CSBC"
   OwnerEmail: "milen.nikolov@sagebase.org"
@@ -43,4 +43,3 @@ hooks:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"
-


### PR DESCRIPTION
Provision RStudio environment to use for

1) final preparations for the 2019 miniDREAM course
2) production environment for the miniDREAM course

Instance will run RStudio along with its public web interface allowing access to an R environment
for about 20 users on the same machine.

Users will perform calculations on datasets, loading potentially dozens of GBs of data in memory, concurrently. No PHI data will be stored here.

Requested instance: r4.16xlarge