### PR TITLE
Update storage location to one using a bucket in the scicomp account

### DIFF
--- a/config/prod/ecmonsen-emorypipeline-lambda.yaml
+++ b/config/prod/ecmonsen-emorypipeline-lambda.yaml
@@ -6,7 +6,7 @@ dependencies:
 parameters:
   # Source account is Emory University AWS account. Contact is Duc Duong
   SourceAccountId: "743849566882"
-  SynapseStorageLocationId: "40930"
+  SynapseStorageLocationId: "40934"
   # AMP-AD Sage Admin https://www.synapse.org/#!Team:3377637
   # Duc Duong https://www.synapse.org/#!Profile:3320325
   # Eva Monsen https://www.synapse.org/#!Profile:3399376


### PR DESCRIPTION
An earlier PR used a bucket in the wrong AWS account. This should fix it.