### PR TITLE
change owner and add individuals access to bucket

### DIFF
--- a/config/prod/usage-statistics-s3.yaml
+++ b/config/prod/usage-statistics-s3.yaml
@@ -7,10 +7,13 @@ parameters:
   # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
   Project: "DataEngineering"
   # The resource owner
-  OwnerEmail: 'kenneth.daily@sagebase.org'
+  OwnerEmail: 'larsson.omberg@sagebase.org'
 
   GrantAccess:
     - 'arn:aws:iam::563295687221:user/kenneth.daily@sagebase.org'
+    - 'arn:aws:iam::563295687221:user/kara.woo@sagebase.org'
+    - 'arn:aws:iam::563295687221:user/larsson.omberg@sagebase.org'
+    - 'arn:aws:iam::563295687221:user/phil.snyder@sagebase.org'
 
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.


### PR DESCRIPTION
This grants access to more users to data queried and stored from the data warehouse to support historical usage query reports (for timeframes greater than 6 months ago). Request for these individuals was requested from @larssono.