### PR TITLE
Rebuild minidream

### DIFF
--- a/config/prod/minidream-R-env-pub-prod-instance-ec2-v2.yaml
+++ b/config/prod/minidream-R-env-pub-prod-instance-ec2-v2.yaml
@@ -18,7 +18,7 @@ parameters:
   KeyName: "scicomp"
   # Get latest AMI Id from https://ami.sageit.org/
   # AMIId: "ami-0810a318c4b1243c5"
-  AMIId: "ami-0b8050b43cdfde2fc"
+  AMIId: "ami-09ddd854571a732be"
 
   # Settings have default values but can be overriden. Set the below
   # parameters *only* if you want to override the defaults.

--- a/config/prod/minidream-R-env-pub-prod-instance-ec2-v2.yaml
+++ b/config/prod/minidream-R-env-pub-prod-instance-ec2-v2.yaml
@@ -1,0 +1,47 @@
+# Provision an EC2 instance
+template_path: remote/managed-ec2-linux-v2.j2
+stack_name: minidream-R-env-pub-prod-instance-ec2-v2
+sceptre_user_data:
+  Distro: "ubuntu"     # (valid values: aws, ubuntu) AMIId must match distro
+  # (Optional) Expose ports to incoming traffic (default is no open ports) (valid range: 1-65535)
+  OpenPorts: ["443"]
+parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "CompOnc"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "CSBC"
+  # The resource owner
+  OwnerEmail: "milen.nikolov@sagebase.org"
+
+  # Default account settings, leave alone unless you plan to override
+  VpcName: "computevpc"
+  KeyName: "scicomp"
+  # Get latest AMI Id from https://ami.sageit.org/
+  # AMIId: "ami-0810a318c4b1243c5"
+  AMIId: "ami-0b8050b43cdfde2fc"
+
+  # Settings have default values but can be overriden. Set the below
+  # parameters *only* if you want to override the defaults.
+
+  # (Optional) EC2 instance type, default is "t3.micro" (other available types https://aws.amazon.com/ec2/pricing/on-demand/)
+  InstanceType: "r4.16xlarge"
+  # (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
+  VolumeSize: "500"
+  # (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
+  # VpcSubnet: "PublicSubnet"
+  # (Optional) Set true to enable daily backups (default: false)
+  BackupEc2: "true"
+  # (Optional) Number of daily backups to keep (default: 7) (valid range: 1-180)
+  SnapshotCount: "3"
+
+  # Integration with our jumpcloud directory service (do not change)
+  JcConnectKey: !ssm /infra/JcConnectKey
+  JcServiceApiKey: !ssm /infra/JcServiceApiKey
+  JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
+
+# For CI system (do not change)
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
+  after_create:
+    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
I believe I used the wrong AMI, which caused provisioning to fail. This uses the packer-ubuntu image instead.