### PR TITLE
[IT-922] Update GrantAccess config for S3 buckets

### DIFF
--- a/config/prod/AMP-Mayo-Sinai-Bucket.yaml
+++ b/config/prod/AMP-Mayo-Sinai-Bucket.yaml
@@ -19,7 +19,7 @@ parameters:
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:iam::563295687221:assumed-role/william.poehlman@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/sandbox-developer/william.poehlman@sagebase.org'
 
   # Restrict downloading files from this bucket to only AWS resources (e.g. EC2 , Lambda)
   # within the same region as this bucket.  This will not allow even the owner of the bucket

--- a/config/prod/AMP-Mayo-Sinai-Bucket.yaml
+++ b/config/prod/AMP-Mayo-Sinai-Bucket.yaml
@@ -19,7 +19,7 @@ parameters:
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:iam::563295687221:user/william.poehlman@sagebase.org'
+    - 'arn:aws:iam::563295687221:assumed-role/william.poehlman@sagebase.org'
 
   # Restrict downloading files from this bucket to only AWS resources (e.g. EC2 , Lambda)
   # within the same region as this bucket.  This will not allow even the owner of the bucket

--- a/config/prod/JKG-SciComp-S3.yaml
+++ b/config/prod/JKG-SciComp-S3.yaml
@@ -19,7 +19,7 @@ parameters:
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:iam::563295687221:assumed-role/jake.gockley@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/sandbox-developer/jake.gockley@sagebase.org'
 
 # For CI system (do not change)
 hooks:

--- a/config/prod/JKG-SciComp-S3.yaml
+++ b/config/prod/JKG-SciComp-S3.yaml
@@ -19,7 +19,7 @@ parameters:
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:iam::563295687221:user/jake.gockley@sagebase.org'
+    - 'arn:aws:iam::563295687221:assumed-role/jake.gockley@sagebase.org'
 
 # For CI system (do not change)
 hooks:

--- a/config/prod/amp-emory-bucket.yaml
+++ b/config/prod/amp-emory-bucket.yaml
@@ -18,7 +18,8 @@ parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'
     - 'arn:aws:iam::743849566882:user/dduong'
-    - 'arn:aws:iam::563295687221:assumed-role/phil.snyder@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/sandbox-developer/phil.snyder@sagebase.org'
+
 hooks:
   before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"

--- a/config/prod/amp-emory-bucket.yaml
+++ b/config/prod/amp-emory-bucket.yaml
@@ -18,7 +18,7 @@ parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'
     - 'arn:aws:iam::743849566882:user/dduong'
-    - 'arn:aws:iam::563295687221:user/phil.snyder@sagebase.org'
+    - 'arn:aws:iam::563295687221:assumed-role/phil.snyder@sagebase.org'
 hooks:
   before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"

--- a/config/prod/usage-statistics-s3.yaml
+++ b/config/prod/usage-statistics-s3.yaml
@@ -10,11 +10,10 @@ parameters:
   OwnerEmail: 'larsson.omberg@sagebase.org'
 
   GrantAccess:
-    - 'arn:aws:iam::563295687221:user/kenneth.daily@sagebase.org'
-    - 'arn:aws:iam::563295687221:user/kara.woo@sagebase.org'
-    - 'arn:aws:iam::563295687221:user/larsson.omberg@sagebase.org'
-    - 'arn:aws:iam::563295687221:user/phil.snyder@sagebase.org'
-    - 'arn:aws:iam::563295687221:user/nicole.kauer@sagebase.org'
+    - 'arn:aws:iam::563295687221:assumed-role/kara.woo@sagebase.org'
+    - 'arn:aws:iam::563295687221:assumed-role/larsson.omberg@sagebase.org'
+    - 'arn:aws:iam::563295687221:assumed-role/phil.snyder@sagebase.org'
+    - 'arn:aws:iam::563295687221:assumed-role/nicole.kauer@sagebase.org'
 
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.

--- a/config/prod/usage-statistics-s3.yaml
+++ b/config/prod/usage-statistics-s3.yaml
@@ -10,10 +10,10 @@ parameters:
   OwnerEmail: 'larsson.omberg@sagebase.org'
 
   GrantAccess:
-    - 'arn:aws:iam::563295687221:assumed-role/kara.woo@sagebase.org'
-    - 'arn:aws:iam::563295687221:assumed-role/larsson.omberg@sagebase.org'
-    - 'arn:aws:iam::563295687221:assumed-role/phil.snyder@sagebase.org'
-    - 'arn:aws:iam::563295687221:assumed-role/nicole.kauer@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/sandbox-developer/kara.woo@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/sandbox-developer/phil.snyder@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/sandbox-developer/larsson.omberg@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/sandbox-developer/nicole.kauer@sagebase.org'
 
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.

--- a/config/prod/veoibd-s3.yaml
+++ b/config/prod/veoibd-s3.yaml
@@ -20,8 +20,7 @@ parameters:
   # (Optional) Allow accounts, groups, and users to access bucket. (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:iam::563295687221:user/kenneth.daily@sagebase.org'
-    - 'arn:aws:iam::563295687221:user/cindy.molitor@sagebase.org'
+    - 'arn:aws:iam::563295687221:assumed-role/cindy.molitor@sagebase.org'
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # EncryptBucket: 'false'
   # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'

--- a/config/prod/veoibd-s3.yaml
+++ b/config/prod/veoibd-s3.yaml
@@ -20,7 +20,8 @@ parameters:
   # (Optional) Allow accounts, groups, and users to access bucket. (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:iam::563295687221:assumed-role/cindy.molitor@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/sandbox-developer/cindy.molitor@sagebase.org'
+
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # EncryptBucket: 'false'
   # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'


### PR DESCRIPTION
Now that we only allow access to AWS thru jumpcloud we need to
update all the GrantAccess configuration in S3 Buckets to the
new assumed role ARN