### PR TITLE
Change source account for Emory, again

### DIFF
--- a/config/prod/ecmonsen-emorypipeline-lambda.yaml
+++ b/config/prod/ecmonsen-emorypipeline-lambda.yaml
@@ -5,7 +5,7 @@ dependencies:
   - prod/ecmonsen-emorypipeline-ci.yaml
 parameters:
   # Source account is Emory University AWS account. Contact is Duc Duong
-  SourceAccountId: "743849566882"
+  SourceAccountId: "607721581289"
   SynapseStorageLocationId: "40934"
   # AMP-AD Sage Admin https://www.synapse.org/#!Team:3377637
   # Duc Duong https://www.synapse.org/#!Profile:3320325


### PR DESCRIPTION
This is a followup to #356; our colleagues at Emory have finished uploading the dataset they needed to upload under the old account, so now I'm changing the source account here to the new one.