### PR TITLE
[IT-937] Setup KMS key for HTAN S3 Synapse Sync

### DIFF
--- a/config/prod/htan-synapse-sync-kms-key.yaml
+++ b/config/prod/htan-synapse-sync-kms-key.yaml
@@ -5,4 +5,4 @@ stack_tags:
   Project: "HTAN"
   OwnerEmail: "xengie.doan@sagebase.org"
 parameters:
-  AdminRoleArn: !stack_output_external jumpcloud-idp::ScicompAdminSamlProviderRoleArn
+  AdminRoleArn: !stack_output_external "jumpcloud-idp::ScicompAdminSamlProviderRoleArn"

--- a/config/prod/htan-synapse-sync-kms-key.yaml
+++ b/config/prod/htan-synapse-sync-kms-key.yaml
@@ -1,0 +1,8 @@
+template_path: "htan-synapse-sync-kms-key.yaml"
+stack_name: "htan-synapse-sync-kms-key"
+stack_tags:
+  Department: "CompOnc"
+  Project: "HTAN"
+  OwnerEmail: "xengie.doan@sagebase.org"
+parameters:
+  AdminRoleArn: !stack_output_external jumpcloud-idp::ScicompAdminSamlProviderRoleArn

--- a/templates/htan-synapse-sync-kms-key.yaml
+++ b/templates/htan-synapse-sync-kms-key.yaml
@@ -1,0 +1,90 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: HTAN SynapseSync KMS Key and IAM policy
+
+Parameters:
+  AdminRoleArn:
+    Type: String
+    Description: ARN of the Administrator Role for a particular account
+
+Resources:
+  KmsDecryptPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ReadAccess
+            Action:
+              - 'kms:Describe*'
+              - 'kms:GetKeyPolicy'
+              - 'kms:GetKeyRotationStatus'
+              - 'kms:List*'
+              - 'kms:Verify'
+            Effect: Allow
+            Resource: !GetAtt KmsKey.Arn
+          - Sid: DecryptAccess
+            Action:
+              - 'kms:Encrypt'
+              - 'kms:Decrypt'
+            Effect: Allow
+            Resource: !GetAtt KmsKey.Arn
+
+  KmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: !Sub '${AWS::StackName}-KmsKey'
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: 'Default KMS Policy that enables IAM permissions'  # https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default
+            Effect: 'Allow'
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action:
+              - 'kms:*'
+            Resource: '*'
+          - Sid: "Allow administration of the key to CFN service role"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !ImportValue
+                    'Fn::Sub': '${AWS::Region}-bootstrap-CfServiceRoleArn'
+                - !Ref AdminRoleArn
+            Action:
+              - "kms:Create*"
+              - "kms:Describe*"
+              - "kms:Enable*"
+              - "kms:List*"
+              - "kms:Put*"
+              - "kms:Update*"
+              - "kms:Revoke*"
+              - "kms:Disable*"
+              - "kms:Get*"
+              - "kms:Delete*"
+              - "kms:ScheduleKeyDeletion"
+              - "kms:CancelKeyDeletion"
+            Resource: "*"
+
+  KmsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub 'alias/${AWS::StackName}/KmsKey'
+      TargetKeyId: !Ref KmsKey
+
+Outputs:
+  KmsKey:
+    Value: !Ref KmsKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsKey'
+  KmsKeyAlias:
+    Value: !Ref KmsKeyAlias
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsKeyAlias'
+  KmsKeyArn:
+    Value: !GetAtt KmsKey.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsKeyArn'
+  KmsDecryptPolicyArn:
+    Value: !Ref KmsDecryptPolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-KmsDecryptPolicyArn'


### PR DESCRIPTION
The S3 Synapse Sync project[1] needs to store secrets in the
AWS SSM. This will create a KMS key to allow us to store those
secrets. The only users that will have access to the key are
AWS account admins and CI systems.

[1] https://github.com/Sage-Bionetworks/s3-synapse-sync