### PR TITLE
[IT-937] Fix bucket policy

### DIFF
--- a/config/prod/htan-bucket-a.yaml
+++ b/config/prod/htan-bucket-a.yaml
@@ -17,4 +17,3 @@ parameters:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
   S3CanonicalUserId: "eab4436941f355ce866fcf7944db42020c385ad1f19df8a95704dc4d7552fa06"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
-  BucketServiceRoleId: !stack_output_external "bootstrap::AWSIAMCfServiceRoleId"

--- a/templates/htan-synapse-bucket.yaml
+++ b/templates/htan-synapse-bucket.yaml
@@ -4,11 +4,6 @@ Description: >-
   Synapse S3 Custom Storage
   (https://docs.synapse.org/articles/custom_storage_location.html)
 Parameters:
-  BucketServiceRoleId:
-    Type: String
-    Description: A service role ID to allow managing objects in the bucket
-    ConstraintDescription: >-
-      Must be a valid AWS role ID (i.e AIDAJQABLZS4A3QDU576Q)
   S3SynapseSyncFunctionRoleArn:
     Type: String
     Description: The S3 Synapse sync lambda function role ARN
@@ -112,8 +107,15 @@ Resources:
               - s3:PutObject
               - s3:PutObjectAcl
             Resource: !Sub "${S3Bucket.Arn}/*"
-          - Effect: Deny
-            Principal: "*"
+          -
+            Sid: "Require canonical ID on object updates"
+            Effect: Deny
+            Principal:
+              AWS: !Split
+                - ","
+                - !Sub
+                  - "${list},${SynapseRootArn}"
+                  - list: !Join [",",!Ref "S3UserARNs"]
             Action: s3:PutObject
             Resource: !Sub "${S3Bucket.Arn}/*"
             Condition:
@@ -121,8 +123,6 @@ Resources:
                 s3:x-amz-grant-full-control: !Sub "id=${SynapseCanonicalId},id=${S3CanonicalUserId}"
               StringNotEquals:
                 s3:x-amz-grant-full-control: !Sub "id=${SynapseCanonicalId}, id=${S3CanonicalUserId}"
-              StringNotLike:
-                "aws:userid": !Join ["", [!Ref BucketServiceRoleId, ":*"]]
 
   # Add owner file to the synapse bucket, requires the cloudformation S3 objects macro
   # https://github.com/Sage-Bionetworks-IT/cfn-s3objects-macro


### PR DESCRIPTION
The strategy for this fix attempt is to deny S3UserARNs
who do not provide canonical account IDs. This works
because S3UserARNs are the only users that have access
to the bucket anyways.

The Previous attempt to fix owner.txt file update with
BucketServiceRoleId condition failed so we remove it..