### PR TITLE
[IT-937] add required AWS lambda permission

### DIFF
--- a/templates/htan-synapse-bucket.yaml
+++ b/templates/htan-synapse-bucket.yaml
@@ -70,12 +70,22 @@ Resources:
             AllowedOrigins: ['*']
             AllowedMethods: [GET, POST, PUT, HEAD]
             MaxAge: 3000
-      NotificationConfiguration:
-        LambdaConfigurations:
-          - Event: "s3:ObjectCreated:*"
-            Function: !Ref S3SynapseSyncFunctionArn
-          - Event: "s3:ObjectRemoved:*"
-            Function: !Ref S3SynapseSyncFunctionArn
+       # LambdaBucketPermission must be setup before NotificationConfiguration
+       # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig.html
+#      NotificationConfiguration:
+#        LambdaConfigurations:
+#          - Event: "s3:ObjectCreated:*"
+#            Function: !Ref S3SynapseSyncFunctionArn
+#          - Event: "s3:ObjectRemoved:*"
+#            Function: !Ref S3SynapseSyncFunctionArn
+  LambdaBucketPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref S3SynapseSyncFunctionArn
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref "AWS::AccountId"
+      SourceArn: !GetAtt S3Bucket.Arn
   S3BucketPolicy:
     Type: "AWS::S3::BucketPolicy"
     Properties:


### PR DESCRIPTION
The previous build failed because the NotificationConfiguration requires
a `AWS::Lambda::Permission` which has not been setup yet.  When
attempting to add that permission and NotificationConfiguration at the
same time we run into a circular dependency problem which is documented
in the NotificationConfiguration docs[1].

The doc is basically saying that the only way to avoid the circular
dependency is to deploy in two steps.  The imnplication is that every
time we create a bucket we would need to deploy the AWS::Lambda::Permission
first then run another deploy to setup the NotificationConfiguration.

This step is o setup the permission.

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig.html