### PR TITLE
remove quotes from BucketVariables parameter

### DIFF
--- a/config/prod/s3-synapse-sync.yaml
+++ b/config/prod/s3-synapse-sync.yaml
@@ -11,9 +11,9 @@ hooks:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/master/s3-synapse-sync.yaml --create-dirs -o templates/remote/s3-synapse-sync.yaml"
 parameters:
   BucketVariables: >-
-    '{
+    {
       "htan-dcc-center-a":{"SynapseProjectId":"syn22343754"},
       "htan-dcc-bu":{"SynapseProjectId":"syn22124336"}
-      }'
+    }
   KmsDecryptPolicyArn: !stack_output_external "htan-synapse-sync-kms-key::KmsDecryptPolicyArn"
   BucketNamePrefix: "htan-dcc-*"


### PR DESCRIPTION
The single quotes wrapping the string appear as literals in the resulting env var value, which I think may be causing an issue when reading it as a dictionary with json.loads()

@zaro0508 @xdoan 