### PR TITLE
Revert "add HTAN collaborator to MSK bucket (#419)"

### DIFF
--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -20,7 +20,6 @@ parameters:
     - "arn:aws:sts::563295687221:assumed-role/sandbox-developer/xengie.doan@sagebase.org"
     - "arn:aws:iam::426577889437:user/clarisse.lau"
     - "arn:aws:iam::289701539771:user/dagutman"
-    - "arn:aws:iam::583643567512:mfa/jchan"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 


### PR DESCRIPTION
This reverts commit 0093e5b7a47f24a3e762396845bd72f7f59467a8.
the ARN "arn:aws:iam::583643567512:mfa/jchan" is invalid.