### PR TITLE
Add Synapse connected buckets for data proc jobs

### DIFF
--- a/config/prod/dian-prod-synapse-import-s3.yaml
+++ b/config/prod/dian-prod-synapse-import-s3.yaml
@@ -4,14 +4,14 @@ template_path: "remote/s3-bucket-v2.j2"
 stack_name: "dian-prod-synapse-import-s3"
 sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
-   SynapseIDs: ["3425758"]  #synapse-service-dian-prod@synapse.org
+  SynapseIDs: ["3425758"]  #synapse-service-dian-prod@synapse.org
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
   Department: "Platform"
   # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
   Project: "DIAN"
   # The resource owner
-  OwnerEmail: "synapse-service-dian-prod@synapse.org"
+  OwnerEmail: "synapse-service+dian-prod@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
 

--- a/config/prod/dian-prod-synapse-import-s3.yaml
+++ b/config/prod/dian-prod-synapse-import-s3.yaml
@@ -1,0 +1,48 @@
+# Provision a general S3 bucket or a Synapse External Bucket
+# http://docs.synapse.org/articles/custom_storage_location.html
+template_path: "remote/s3-bucket-v2.j2"
+stack_name: "dian-prod-synapse-import-s3"
+sceptre_user_data:
+  # (Optional) Synapse IDs for owner.txt file
+   SynapseIDs: ["3425758"]  #synapse-service-dian-prod@synapse.org
+parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "Platform"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "DIAN"
+  # The resource owner
+  OwnerEmail: "synapse-service-dian-prod@synapse.org"
+  # (Optional) true for read-write bucket, false (default) for read-only bucket
+  AllowWriteBucket: "true"
+
+  # Settings have default values but can be overriden. Set the below
+  # parameters *only* if you want to override the defaults.
+
+  # THIS CURRENTLY ONLY WORKS IN THE us-east-1 REGION!!!!!
+  # Data transfers within the same region between AWS resources are free.
+  # true to restrict downloading files from this bucket to only AWS resources (e.g. EC2 , Lambda) within the same region as this bucket.
+  # This will not allow even the owner of the bucket to download objects in this bucket when not using an AWS resource in the same region!
+  SameRegionResourceAccessToBucket: "true"
+
+  # (Optional) Allow accounts, groups, and users to access bucket. (default is no access).
+  GrantAccess:
+    - "arn:aws:iam::325565585839:root"   # Required ARN for a synapse bucket
+  # (Optional) true (default) to encrypt bucket, false for no encryption
+  # EncryptBucket: 'false'
+  # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'
+  # BucketVersioning: 'Enabled'
+  # (Optional) 'Enabled' to enable bucket data life cycle rule, default is 'Disabled'
+  # EnableDataLifeCycle: 'Enabled'
+  # (Optional) S3 bucket objects will transition into this storage class: GLACIER(default), DEEP_ARCHIVE, INTELLIGENT_TIERING, STANDARD_IA, ONEZONE_IA
+  # LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+  # (Optional) Number of days until S3 objects are moved to the LifecycleDataStorageClass, default is 30
+  # LifecycleDataTransition: '90'
+  # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000
+  # LifecycleDataExpiration: '1825'
+
+# For CI system (do not change)
+hooks:
+  before_launch:
+    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket-v2.j2 -N -P templates/remote"
+  after_create:
+    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dian-uat-synapse-import-s3.yaml
+++ b/config/prod/dian-uat-synapse-import-s3.yaml
@@ -1,0 +1,48 @@
+# Provision a general S3 bucket or a Synapse External Bucket
+# http://docs.synapse.org/articles/custom_storage_location.html
+template_path: "remote/s3-bucket-v2.j2"
+stack_name: "dian-uat-synapse-import-s3"
+sceptre_user_data:
+  # (Optional) Synapse IDs for owner.txt file
+   SynapseIDs: ["3425757"]  #synapse-service-dian-uat@synapse.org
+parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "Platform"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "DIAN"
+  # The resource owner
+  OwnerEmail: "synapse-service-dian-uat@synapse.org"
+  # (Optional) true for read-write bucket, false (default) for read-only bucket
+  AllowWriteBucket: "true"
+
+  # Settings have default values but can be overriden. Set the below
+  # parameters *only* if you want to override the defaults.
+
+  # THIS CURRENTLY ONLY WORKS IN THE us-east-1 REGION!!!!!
+  # Data transfers within the same region between AWS resources are free.
+  # true to restrict downloading files from this bucket to only AWS resources (e.g. EC2 , Lambda) within the same region as this bucket.
+  # This will not allow even the owner of the bucket to download objects in this bucket when not using an AWS resource in the same region!
+  SameRegionResourceAccessToBucket: "true"
+
+  # (Optional) Allow accounts, groups, and users to access bucket. (default is no access).
+  GrantAccess:
+    - "arn:aws:iam::325565585839:root"   # Required ARN for a synapse bucket
+  # (Optional) true (default) to encrypt bucket, false for no encryption
+  # EncryptBucket: 'false'
+  # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'
+  # BucketVersioning: 'Enabled'
+  # (Optional) 'Enabled' to enable bucket data life cycle rule, default is 'Disabled'
+  # EnableDataLifeCycle: 'Enabled'
+  # (Optional) S3 bucket objects will transition into this storage class: GLACIER(default), DEEP_ARCHIVE, INTELLIGENT_TIERING, STANDARD_IA, ONEZONE_IA
+  # LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+  # (Optional) Number of days until S3 objects are moved to the LifecycleDataStorageClass, default is 30
+  # LifecycleDataTransition: '90'
+  # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000
+  # LifecycleDataExpiration: '1825'
+
+# For CI system (do not change)
+hooks:
+  before_launch:
+    - !cmd "wget https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket-v2.j2 -N -P templates/remote"
+  after_create:
+    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dian-uat-synapse-import-s3.yaml
+++ b/config/prod/dian-uat-synapse-import-s3.yaml
@@ -4,14 +4,14 @@ template_path: "remote/s3-bucket-v2.j2"
 stack_name: "dian-uat-synapse-import-s3"
 sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
-   SynapseIDs: ["3425757"]  #synapse-service-dian-uat@synapse.org
+  SynapseIDs: ["3425757"]  #synapse-service-dian-uat@synapse.org
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
   Department: "Platform"
   # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
   Project: "DIAN"
   # The resource owner
-  OwnerEmail: "synapse-service-dian-uat@synapse.org"
+  OwnerEmail: "synapse-service+dian-uat@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
 


### PR DESCRIPTION
- [x] This change makes uat/prod buckets connected to synapse and owned by Synapse service accounts. These are the for the output of data processing jobs that will run in scicomp, including for app migration and for R proc
- [x] Passes pre-commit