### PR TITLE
Peg deployed Synapse-attached bucket to v0.2.5 aws-infra tag

### DIFF
--- a/config/prod/TESLA-download-bucket.yaml
+++ b/config/prod/TESLA-download-bucket.yaml
@@ -44,6 +44,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/v0.2.5/s3-bucket-v2.j2 --create-dirs -o templates/remote/s3-bucket-v2.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/v0.2.8/s3-bucket-v2.j2 --create-dirs -o templates/remote/s3-bucket-v2.j2"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/TESLA-download-bucket.yaml
+++ b/config/prod/TESLA-download-bucket.yaml
@@ -44,6 +44,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/master/s3-bucket-v2.j2 --create-dirs -o templates/remote/s3-bucket-v2.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/v0.2.5/s3-bucket-v2.j2 --create-dirs -o templates/remote/s3-bucket-v2.j2"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
- [x] This change pegs the only deployed Synapse-attached S3 bucket to v0.2.5 of aws-infra so that https://github.com/Sage-Bionetworks/aws-infra/pull/284/ can be merged without risk of breaking the deployed bucket connection
- [x] Passes pre-commit

https://github.com/Sage-Bionetworks/aws-infra/pull/284 depends on this if we want to merge it to unblock https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/458