### PR TITLE
Add admin SSO role for manual Synapse file_handle linking

### DIFF
--- a/config/prod/dian-uat-hm-migration-s3.yaml
+++ b/config/prod/dian-uat-hm-migration-s3.yaml
@@ -28,6 +28,7 @@ parameters:
   GrantAccess:
     - "arn:aws:iam::325565585839:root"   # Required ARN for a synapse bucket
     - "arn:aws:iam::024584448019:user/cleardata/customer/michael.votaw"
+    - "arn:aws:iam::055273631518:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_1087bdcd71db6704"
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # EncryptBucket: 'false'
   # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'


### PR DESCRIPTION
- [x] This is a temporary change to the UAT deployment to manually link the files already in the bucket to Synapse and can be revoked after linking.
- [x] Passes pre-commit