### PR TITLE
Remove user reference

### DIFF
--- a/config/prod/AMP-Emory-Bucket.yaml
+++ b/config/prod/AMP-Emory-Bucket.yaml
@@ -17,7 +17,6 @@ parameters:
   # Allow accounts, groups, and users to access bucket.
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'
-    - 'arn:aws:iam::743849566882:user/dduong'
     - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/phil.snyder@sagebase.org'
 
 hooks:


### PR DESCRIPTION
AWS reports that 'arn:aws:iam::743849566882:user/dduong' is no
longer a valid principal which caused the CI deployment to fail.
We remove this principal to fix the deployment.

From AWS...
```
Invalid principal in policy (Service: Amazon S3; Status Code: 400;
Error Code: MalformedPolicy; Request ID: 0G10HESHZRCRNJ70;
S3 Extended Request ID: 7+tqQX7+p4+AIEKRRQcg1L9WfMXJvex2R5uM6H5qQaUxUBSGFvd1SMhgUdUjpqYg466qRN5OwVI=;
Proxy: null)
```