### PR TITLE
Provision miniDREAM 2021 infrastructure

### DIFF
--- a/config/prod/minidream-rstudio-2021-ec2-alb.yaml
+++ b/config/prod/minidream-rstudio-2021-ec2-alb.yaml
@@ -1,0 +1,22 @@
+# Provision a public load balancer in front of private miniDREAM EC2
+# Based on prod/minidream-R-env-pub-prod-instance-ec2-alb-v2.yaml
+template_path: "remote/managed-alb-https-v2.yaml"
+stack_name: "minidream-rstudio-2021-ec2-alb"
+
+parameters:
+  Department: "CompOnc"
+  Project: "CSBC"
+  OwnerEmail: "bruno.grande@sagebase.org"
+  Ec2InstanceId: !stack_output "prod/minidream-rstudio-2021-ec2.yaml::Ec2InstanceId"
+  SSLCertificateIdArn: "arn:aws:acm:us-east-1:055273631518:certificate/992c2d49-579a-465e-beff-1a08c284f7db"
+  VpcId: "vpc-e66bd19d"   # computevpc
+  AppPort: "443"          # nginx reverse proxy
+  Subnets: "subnet-21a68d7c,subnet-4f3e2b2b,subnet-77d1e458"  # public subnets
+
+# After deployment, Ec2SecurityGroup must be manually attached to the EC2 referenced by Ec2InstanceId:
+# https://github.com/Sage-Bionetworks/aws-infra/blob/v0.2.13/templates/managed-alb-https-v2.yaml#L5-L8
+# Also, update DNS for minidream.synapse.org to point to this ALB once deployed.
+
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.13/managed-alb-https-v2.yaml -N -P templates/remote"

--- a/config/prod/minidream-rstudio-2021-ec2.yaml
+++ b/config/prod/minidream-rstudio-2021-ec2.yaml
@@ -1,0 +1,29 @@
+# Provision an EC2 instance for hosting miniDREAM RStudio server
+# Based on prod/minidream-R-env-pub-prod-instance-ec2-v2.yaml
+template_path: "remote/managed-ec2-linux-v2.j2"
+stack_name: "minidream-rstudio-2021-ec2"
+
+sceptre_user_data:
+  Distro: "ubuntu"
+  OpenPorts: ["443"]  # On a private subnet (default)
+parameters:
+  Department: "CompOnc"
+  Project: "CSBC"
+  OwnerEmail: "bruno.grande@sagebase.org"
+  VpcName: "computevpc"
+  KeyName: "scicomp"
+  AMIId: "ami-0b7906ab614596e7e"  # packer-base-ubuntu-bionic-v1.0.9
+  InstanceType: "x1.16xlarge"     # 64 vCPUs / 976 GiB / 1920 GiB SSD
+  VolumeSize: "500"
+  BackupEc2: "true"
+  SnapshotCount: "3"
+
+  JcConnectKey: !ssm "/infra/JcConnectKey"
+  JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
+  JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
+
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.13/managed-ec2-linux-v2.j2 -N -P templates/remote"
+  after_create:
+    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
I'm deploying infrastructure for miniDREAM 2021. This stack is composed of a high-memory EC2 instance in a private subnet behind by a public load balancer (both using existing aws-infra templates). 

We will be hosting RStudio on port 8787 of this instance, and we will setup an nginx reverse proxy to redirect incoming HTTPS (port 443) traffic from the ALB to port 8787. The ALB will take care of upgrading HTTP (port 80) traffic to HTTPS (port 443). 

We have a custom setup to integrate with Synapse evaluation queues, so we can't use the RStudio packer AMI. 