### PR TITLE
Change `stack_output` to `stack_output_external` for miniDREAM 2021 ALB

### DIFF
--- a/config/prod/minidream-rstudio-2021-ec2-alb.yaml
+++ b/config/prod/minidream-rstudio-2021-ec2-alb.yaml
@@ -8,7 +8,7 @@ parameters:
   Department: "CompOnc"
   Project: "CSBC"
   OwnerEmail: "bruno.grande@sagebase.org"
-  Ec2InstanceId: !stack_output "prod/minidream-rstudio-2021-ec2.yaml::Ec2InstanceId"
+  Ec2InstanceId: !stack_output_external "minidream-rstudio-2021-ec2::Ec2InstanceId"
   SSLCertificateIdArn: "arn:aws:acm:us-east-1:055273631518:certificate/992c2d49-579a-465e-beff-1a08c284f7db"
   VpcId: "vpc-e66bd19d"   # computevpc
   AppPort: "443"          # nginx reverse proxy


### PR DESCRIPTION
I'm using [this](https://github.com/Sage-Bionetworks-Workflows/aws-workflows-nextflow-infra/blob/main/config/common/nextflow-forge-service-user.yaml#L6-L9) as a working example. 