### PR TITLE
[IT-1295] fix travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ install:
   - ./setup_aws_cli.sh || travis_terminate 1
   - pip install pre-commit sceptre sceptre-ssm-resolver
   - pip install git+git://github.com/Sage-Bionetworks/sceptre-provisioner-hooks.git
+before_script:
+  # force wget in sceptre templates to download the latest templates
+  - rm -rf templates/remote
 stages:
   - name: validate
   - name: deploy


### PR DESCRIPTION
Travis is cacheing templates which can sometimes cause resources
to provision with old templates.  We delete the foler containing
downloaded templates to force travis to downlod them on every
deployment.