### PR TITLE
Switch HTAN buckets to `BucketOwnerEnforced`

### DIFF
--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-chop"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-dfci"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-duke"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-hms"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-msk"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-ohsu"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-pcapp"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-stanford"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tma-tnp"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tnp-sardana"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -1,14 +1,13 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
-template_path: "remote/s3-synapse-sync-bucket.j2"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-vanderbilt"
 stack_tags:
   Department: "CompOnc"
   Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync-bucket.j2 --create-dirs -o templates/remote/s3-synapse-sync-bucket.j2"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/s3-synapse-sync.yaml
+++ b/config/prod/s3-synapse-sync.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/s3-synapse-sync.yaml"
+template:
+  type: "http"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.0/s3-synapse-sync.yaml"
 stack_name: "s3-synapse-sync"
 stack_tags:
   Department: "CompOnc"
@@ -6,9 +8,6 @@ stack_tags:
   OwnerEmail: "bruno.grande@sagebase.org"
 dependencies:
   - "prod/htan-synapse-sync-kms-key.yaml"
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.5.0/s3-synapse-sync.yaml --create-dirs -o templates/remote/s3-synapse-sync.yaml"
 parameters:
   BucketVariables: >-
     {


### PR DESCRIPTION
Deploying the change introduced in Sage-Bionetworks/s3-synapse-sync#44, which switches the object ownership setting to `BucketOwnerEnforced`, for all HTAN S3 buckets

(@BrunoGrandePhD)