### PR TITLE
Use sceptre template handlers

### DIFF
--- a/config/prod/AMP-Emory-Bucket.yaml
+++ b/config/prod/AMP-Emory-Bucket.yaml
@@ -1,5 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "AMP-Emory-Bucket"
 parameters:
   # The Sage deparment for this resource
@@ -19,9 +21,3 @@ parameters:
     - 'arn:aws:iam::325565585839:root'
     - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/phil.snyder@sagebase.org'
     - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/nicole.kauer@sagebase.org'
-
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !synapse_bucket_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/JKG-SciComp-S3.yaml
+++ b/config/prod/JKG-SciComp-S3.yaml
@@ -1,5 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "JKG-SciComp-S3"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)

--- a/config/prod/TESLA-download-bucket.yaml
+++ b/config/prod/TESLA-download-bucket.yaml
@@ -1,6 +1,8 @@
 # Provision a general S3 bucket or a Synapse External Bucket
 # http://docs.synapse.org/articles/custom_storage_location.html
-template_path: "remote/s3-bucket-v2.j2"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/v0.2.7/s3-bucket-v2.j2"
 stack_name: "TESLA-download-bucket"
 sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
@@ -40,10 +42,3 @@ parameters:
   # LifecycleDataTransition: '90'
   # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000
   # LifecycleDataExpiration: '1825'
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/v0.2.7/s3-bucket-v2.j2 --create-dirs -o templates/remote/s3-bucket-v2.j2"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/aacr-interactome-s3website-new.yaml
+++ b/config/prod/aacr-interactome-s3website-new.yaml
@@ -1,5 +1,7 @@
 # Provision a S3 static website for AACR Interactome
-template_path: "remote/managed-s3WebCloudfront.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-s3WebCloudfront.yaml"
 stack_name: "aacr-interactome-s3website-new"
 parameters:
   # The department for this resource (i.e. CompOnc, SysBio, Platform, etc..)
@@ -14,9 +16,3 @@ parameters:
   SubDomainName: "cancer"
   # The Amazon Resource Name (ARN) of an AWS Certificate Manager (ACM) certificate
   AcmCertificateArn: "arn:aws:acm:us-east-1:055273631518:certificate/62283392-710d-439e-ad40-3b53a6a78499"
-
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-s3WebCloudfront.yaml --create-dirs -o templates/remote/managed-s3WebCloudfront.yaml"
-  after_create:
-    - !s3_web_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/amp-mayo-sinai.yaml
+++ b/config/prod/amp-mayo-sinai.yaml
@@ -1,5 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "amp-mayo-sinai"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -29,10 +31,3 @@ parameters:
   # Enable Intelligent-tiering storage
   EnableDataLifeCycle: 'Enabled'
   LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/belltown-solly-2019.yaml
+++ b/config/prod/belltown-solly-2019.yaml
@@ -1,5 +1,7 @@
 # Provision an EC2 instance
-template_path: "remote/managed-ec2-linux-v1.j2"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v1.j2"
 stack_name: "belltown-solly-2019"
 sceptre_user_data:
   Distro: "ubuntu"     # (valid values: aws, ubuntu) AMIId must match distro
@@ -36,10 +38,3 @@ parameters:
   JcConnectKey: !ssm "/infra/JcConnectKey"
   JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
   JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  after_create:
-    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ecmonsen-emorypipeline-ci.yaml
+++ b/config/prod/ecmonsen-emorypipeline-ci.yaml
@@ -1,4 +1,5 @@
-template_path: "ecmonsen-emorypipeline-ci.yaml"
+template:
+  path: "ecmonsen-emorypipeline-ci.yaml"
 stack_name: "ecmonsen-emorypipeline-ci"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)

--- a/config/prod/ecmonsen-emorypipeline-lambda.yaml
+++ b/config/prod/ecmonsen-emorypipeline-lambda.yaml
@@ -1,4 +1,6 @@
-template_path: "remote/ecmonsen-emorypipeline-lambda.yaml"
+template:
+  type: "http"
+  url: "https://ecmonsen-emorypipeline-ci-lambdaartifactsbucket-jnlt9zs4haa7.s3.amazonaws.com/lambda-uploader/v1.0.3/ecmonsen-emorypipeline-lambda.yaml"
 # Note stack name must be 43 chars or less, otherwise bucket name is too long and CloudFormation fails
 stack_name: "ecmonsen-emorypipeline-lambda"
 dependencies:
@@ -16,6 +18,3 @@ parameters:
   Project: "amp-ad"
   OwnerEmail: "tess.thyer@sagebase.org"
   SynapseUserName: "amp-ad-uploader"
-hooks:
-  before_launch:
-    - !cmd "curl https://ecmonsen-emorypipeline-ci-lambdaartifactsbucket-jnlt9zs4haa7.s3.amazonaws.com/lambda-uploader/v1.0.3/ecmonsen-emorypipeline-lambda.yaml --create-dirs -o templates/remote/ecmonsen-emorypipeline-lambda.yaml"

--- a/config/prod/gates-ki-001.yaml
+++ b/config/prod/gates-ki-001.yaml
@@ -1,5 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "gates-ki-001"
 parameters:
   # The Sage deparment for this resource
@@ -17,8 +19,3 @@ parameters:
   # Allow accounts, groups, and users to access bucket.
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !synapse_bucket_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/htan-synapse-sync-kms-key.yaml
+++ b/config/prod/htan-synapse-sync-kms-key.yaml
@@ -1,4 +1,5 @@
-template_path: "htan-synapse-sync-kms-key.yaml"
+template:
+  path: "htan-synapse-sync-kms-key.yaml"
 stack_name: "htan-synapse-sync-kms-key"
 stack_tags:
   Department: "CompOnc"

--- a/config/prod/mep-lincs-s3.yaml
+++ b/config/prod/mep-lincs-s3.yaml
@@ -3,7 +3,9 @@
 
 # For use in the MEP-LINCS Synapse Project https://www.synapse.org/mep_lincs
 
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "mep-lincs-s3"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -17,10 +19,3 @@ parameters:
   SynapseUserName: 'larssono'
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required
-
- # For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/psorcast-ec2.yaml
+++ b/config/prod/psorcast-ec2.yaml
@@ -17,7 +17,3 @@ parameters:
   JcConnectKey: !ssm "/infra/JcConnectKey"
   JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
   JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
-
-hooks:
-  after_create:
-    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/shinyserver-pro-prod-alb-v2.yaml
+++ b/config/prod/shinyserver-pro-prod-alb-v2.yaml
@@ -1,5 +1,7 @@
 # Provision a load balancer for shiny.synapse.org
-template_path: "remote/managed-alb-https-v2.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-alb-https-v2.yaml"
 stack_name: "shinyserver-pro-prod-alb-v2"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -18,7 +20,3 @@ parameters:
     - !stack_output_external "computevpc::PublicSubnet"
     - !stack_output_external "computevpc::PublicSubnet1"
     - !stack_output_external "computevpc::PublicSubnet2"
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-alb-https-v2.yaml --create-dirs -o templates/remote/managed-alb-https-v2.yaml"

--- a/config/prod/shinyserver-pro-prod.yaml
+++ b/config/prod/shinyserver-pro-prod.yaml
@@ -1,5 +1,7 @@
 # Provision an EC2 instance
-template_path: "remote/managed-ec2-linux-v2.j2"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v2.j2"
 stack_name: "shinyserver-pro-prod"
 sceptre_user_data:
   Distro: "ubuntu"     # (valid values: aws, ubuntu) AMIId must match distro
@@ -37,10 +39,3 @@ parameters:
   JcConnectKey: !ssm "/infra/JcConnectKey"
   JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
   JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
-  after_create:
-    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/usage-statistics-S3.yaml
+++ b/config/prod/usage-statistics-S3.yaml
@@ -1,5 +1,7 @@
 # For storage of files related to usage statistics reporting
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "usage-statistics-S3"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -19,10 +21,3 @@ parameters:
 
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/veoibd-s3.yaml
+++ b/config/prod/veoibd-s3.yaml
@@ -1,6 +1,8 @@
 # Provision a general S3 bucket or a Synapse External Bucket
 # http://docs.synapse.org/articles/custom_storage_location.html
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "veoibd-s3"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -34,10 +36,3 @@ parameters:
   # LifecycleDataTransition: '90'
   # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000
   # LifecycleDataExpiration: '1825'
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
Sceptre supports template handlers[1] to get remote templates so we no
longer need to use hooks.  Convert all hooks to template handler.

[1] https://docs.sceptre-project.org/dev/docs/template_handlers.html
