### PR TITLE
create mini dream 2022 ec2 and alb

### DIFF
--- a/config/prod/minidream-rstudio-2022-ec2-alb.yaml
+++ b/config/prod/minidream-rstudio-2022-ec2-alb.yaml
@@ -2,7 +2,7 @@
 # Based on the PR here: https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/504/files
 
 template:
-  type: http
+  type: "http"
   url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/managed-alb-https-v2.yaml"
 stack_name: "minidream-rstudio-2022-ec2-alb"
 dependencies:

--- a/config/prod/minidream-rstudio-2022-ec2-alb.yaml
+++ b/config/prod/minidream-rstudio-2022-ec2-alb.yaml
@@ -1,0 +1,23 @@
+# Provision a public load balancer in front of private miniDREAM EC2
+# Based on the PR here: https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/504/files
+
+template:
+  type: http
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/managed-alb-https-v2.yaml"
+stack_name: "minidream-rstudio-2022-ec2-alb"
+dependencies:
+  - "prod/minidream-rstudio-2022-ec2.yaml"
+parameters:
+  Department: "SCCE"
+  Project: "CSBC"
+  OwnerEmail: "lingling.peng@sagebase.org"
+  Ec2InstanceId: !stack_output_external "minidream-rstudio-2022-ec2::Ec2InstanceId"
+  SSLCertificateIdArn: "arn:aws:acm:us-east-1:055273631518:certificate/992c2d49-579a-465e-beff-1a08c284f7db"
+  VpcId: "vpc-e66bd19d"   # computevpc
+  AppPort: "443"          # nginx reverse proxy
+  Subnets: "subnet-21a68d7c,subnet-4f3e2b2b,subnet-77d1e458"  # public subnets
+stack_tags:
+  CostCenter: "CSBC - NCI / 101300"
+# After deployment, Ec2SecurityGroup must be manually attached to the EC2 referenced by Ec2InstanceId:
+# https://github.com/Sage-Bionetworks/aws-infra/blob/v0.2.13/templates/managed-alb-https-v2.yaml#L5-L8
+# Also, update DNS for minidream.synapse.org to point to this ALB once deployed.

--- a/config/prod/minidream-rstudio-2022-ec2.yaml
+++ b/config/prod/minidream-rstudio-2022-ec2.yaml
@@ -2,7 +2,7 @@
 # Based on the PR here: https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/504/files
 
 template:
-  type: http
+  type: "http"
   url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/EC2/jc-ec2-linux.j2"
 stack_name: "minidream-rstudio-2022-ec2"
 
@@ -13,7 +13,7 @@ parameters:
   VpcName: "computevpc"
   #KeyName: "scicomp" #relying on JcUserId instead
   AMIId: "ami-0b7906ab614596e7e"  # packer-base-ubuntu-bionic-v1.0.9
-  InstanceType: "x1.16xlarge"     # 64 vCPUs / 976 GiB / 1920 GiB SSD
+  InstanceType: "x2gd.8xlarge"     # 64 vCPUs / 976 GiB / 1920 GiB SSD
   VolumeSize: "500"
   BackupEc2: "true"
   SnapshotCount: "3"

--- a/config/prod/minidream-rstudio-2022-ec2.yaml
+++ b/config/prod/minidream-rstudio-2022-ec2.yaml
@@ -13,7 +13,7 @@ parameters:
   VpcName: "computevpc"
   #KeyName: "scicomp" #relying on JcUserId instead
   AMIId: "ami-0b7906ab614596e7e"  # packer-base-ubuntu-bionic-v1.0.9
-  InstanceType: "x2gd.8xlarge"     # 64 vCPUs / 976 GiB / 1920 GiB SSD
+  InstanceType: "x2gd.8xlarge"     # 32 vCPUs / 512 GiB
   VolumeSize: "500"
   BackupEc2: "true"
   SnapshotCount: "3"

--- a/config/prod/minidream-rstudio-2022-ec2.yaml
+++ b/config/prod/minidream-rstudio-2022-ec2.yaml
@@ -1,0 +1,32 @@
+# Provision an EC2 instance for hosting miniDREAM RStudio server
+# Based on the PR here: https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/504/files
+
+template:
+  type: http
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/EC2/jc-ec2-linux.j2"
+stack_name: "minidream-rstudio-2022-ec2"
+
+sceptre_user_data:
+  Distro: "ubuntu"
+  OpenPorts: ["443"]  # On a private subnet (default)
+parameters:
+  VpcName: "computevpc"
+  #KeyName: "scicomp" #relying on JcUserId instead
+  AMIId: "ami-0b7906ab614596e7e"  # packer-base-ubuntu-bionic-v1.0.9
+  InstanceType: "x1.16xlarge"     # 64 vCPUs / 976 GiB / 1920 GiB SSD
+  VolumeSize: "500"
+  BackupEc2: "true"
+  SnapshotCount: "3"
+  JcUserId: "lingling.peng@sagebase.org"
+
+  JcConnectKey: !ssm "/infra/JcConnectKey"
+  JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
+  JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
+stack_tags:
+  Department: "SCCE"
+  Project: "CSBC"
+  OwnerEmail: "lingling.peng@sagebase.org"
+  CostCenter: "CSBC - NCI / 101300"
+hooks:
+  after_create:
+    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/minidream-rstudio-2022-ec2.yaml
+++ b/config/prod/minidream-rstudio-2022-ec2.yaml
@@ -11,8 +11,7 @@ sceptre_user_data:
   OpenPorts: ["443"]  # On a private subnet (default)
 parameters:
   VpcName: "computevpc"
-  #KeyName: "scicomp" #relying on JcUserId instead
-  AMIId: "ami-0b7906ab614596e7e"  # packer-base-ubuntu-bionic-v1.0.9
+  AMIId: "ami-0a3c3e0cb6ae0cc6c"  # packer-base-ubuntu-bionic-v1.0.9
   InstanceType: "x2gd.8xlarge"     # 32 vCPUs / 512 GiB
   VolumeSize: "500"
   BackupEc2: "true"
@@ -27,6 +26,3 @@ stack_tags:
   Project: "CSBC"
   OwnerEmail: "lingling.peng@sagebase.org"
   CostCenter: "CSBC - NCI / 101300"
-hooks:
-  after_create:
-    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
This PR is related to the issue here [#issue](https://github.com/Sage-Bionetworks/minidream-r-env/issues/22). This stack is composed of a high-memory EC2 instance in a private subnet behind by a public load balancer (both using existing aws-infra templates). This instance will provide RStudio environment for 20-30 students taking miniDream courses. 

Based on Bruno's comment below, the size of instance that we need is: x2gd.8xlarge (32 vCPUs / 512 GiB )

*Note*: This PR is based on the PR in previous year [here](https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/504/files). More context could also be found [here](https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/478)

We have run `pre-commit` for our files: 
```
(venv) lpeng@w153 scicomp-provisioner % pre-commit run --files config/prod/minidream*
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
yamllint.................................................................Passed
AWS CloudFormation Linter............................(no files to check)Skipped
Tabs remover.............................................................Passed
check file names.........................................................Passed
check stack names........................................................Passed
check stack tags.........................................................Passed

```

depends on https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/pull/30