### PR TITLE
update instance type to make it compatible to AMI

### DIFF
--- a/config/prod/minidream-rstudio-2022-ec2.yaml
+++ b/config/prod/minidream-rstudio-2022-ec2.yaml
@@ -13,7 +13,7 @@ parameters:
   KeyName: "scicomp"
   VpcName: "computevpc"
   AMIId: "ami-0a3c3e0cb6ae0cc6c"  # packer-base-ubuntu-bionic-v1.0.9
-  InstanceType: "x2gd.8xlarge"     # 32 vCPUs / 512 GiB
+  InstanceType: "r5a.12xlarge"     # 32 vCPUs / 512 GiB
   VolumeSize: "500"
   BackupEc2: "true"
   SnapshotCount: "3"


### PR DESCRIPTION
Due to this [deployment error](https://app.travis-ci.com/github/Sage-Bionetworks/scicomp-provisioner/jobs/570370657) (deployment failed because the selected instance type did not match the architecture of the selected AMI), there are two solutions
- Update the AMI
- Update the instance type


We elected to update the instance type to match the architecture of the AMI.


This PR is related to the PR we have [here](https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/522).

Note: pre-commit results:

```
(venv) lpeng@w153 scicomp-provisioner % pre-commit run --all-files
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
yamllint.................................................................Passed
AWS CloudFormation Linter................................................Passed
Tabs remover.............................................................Passed
check file names.........................................................Passed
check stack names........................................................Passed
check stack tags.........................................................Passed
```
