### PR TITLE
Remove invalid principal

### DIFF
--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -19,7 +19,6 @@ parameters:
   S3UserARNs:
     - "arn:aws:iam::583643567512:user/jchan"
     - "arn:aws:iam::070278699608:user/inodb"
-    - "arn:aws:iam::583643567512:user/vianne"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org"
     - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/adam.taylor@sagebase.org"
@@ -28,7 +27,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   DenyDeleteARNs:
     - "arn:aws:iam::583643567512:user/jchan"
-    - "arn:aws:iam::583643567512:user/vianne"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jason.hwee@sagebase.org"
     - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/adam.taylor@sagebase.org"


### PR DESCRIPTION
Update of the htan-dcc-mask.yaml template caused the following error

```
Invalid principal in policy (Service: Amazon S3; Status Code: 400;
Error Code: MalformedPolicy;
Request ID: J52TDYYBDSYQZ2NM;
S3 Extended Request ID: 5VGYomX+aw8OzIEFUscuNmpm201vipMcQmczsDrgQMCroy1Bdb2WXggVHZs8pQ6HIGr9Mj6eP+E=;
```

Testing indicates that `arn:aws:iam::583643567512:user/vianne`
might be an invalid user.  Remove this invalid user from the
bucket policy to fix the deployment failure.