### PR TITLE
[IT-1531] Use sceptrelint validate stack tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
@@ -9,12 +9,12 @@ repos:
     hooks:
     -   id: yamllint
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.58.2
+    rev: v0.61.0
     hooks:
     -   id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.13
+    rev: v1.2.0
     hooks:
     -   id: remove-tabs
 -   repo: https://github.com/sceptre/sceptrelint
@@ -26,5 +26,5 @@ repos:
          args: [--tag=CostCenter,
                 --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/tags/SageFinancialProgramCodes.json,
                 --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/tags/SageFinancialProgramCodesOther.json,
-                --exclude="Other / 000001"
+                --exclude=Other / 000001
          ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.1.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
@@ -9,12 +9,12 @@ repos:
     hooks:
     -   id: yamllint
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.61.0
+    rev: v0.58.2
     hooks:
     -   id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.2.0
+    rev: v1.1.13
     hooks:
     -   id: remove-tabs
 -   repo: https://github.com/sceptre/sceptrelint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,6 @@ repos:
     -    id: check-stack-tag-values
          args: [--tag=CostCenter,
                 --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/tags/SageFinancialProgramCodes.json,
-                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/tags/SageFinancialProgramCodesOther.json]
+                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/tags/SageFinancialProgramCodesOther.json,
+                --exclude="Other / 000001"
+         ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,11 @@ repos:
     hooks:
     -   id: remove-tabs
 -   repo: https://github.com/sceptre/sceptrelint
-    rev: v1.0.1
+    rev: v1.1.0
     hooks:
     -    id: check-file-names
     -    id: check-stack-names
-    -    id: check-stack-tags
-         args: [--tag=CostCenter]
+    -    id: check-stack-tag-values
+         args: [--tag=CostCenter,
+                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/tags/SageFinancialProgramCodes.json,
+                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/tags/SageFinancialProgramCodesOther.json]


### PR DESCRIPTION
Use the new precommit linter to validate that the assigned CostCenter
tags are valid.

depends on https://github.com/Sceptre/sceptrelint/pull/6
