### PR TITLE
Switch to scicomp role for administering HTAN buckets

### DIFF
--- a/config/prod/htan-dcc-center-a.yaml
+++ b/config/prod/htan-dcc-center-a.yaml
@@ -31,7 +31,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -30,7 +30,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -30,7 +30,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -34,7 +34,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -32,7 +32,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -35,7 +35,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -33,7 +33,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -28,7 +28,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -32,7 +32,7 @@ parameters:
     - "arn:aws:iam::292075781285:user/idp-import"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -34,7 +34,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -36,7 +36,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -30,7 +30,7 @@ parameters:
     - "arn:aws:iam::292075781285:user/idp-import"
   S3AdminARNs:
     - "arn:aws:iam::426577889437:user/clarisse.lau"
-    - "arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/bruno.grande@sagebase.org"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/bruno.grande@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
 


### PR DESCRIPTION
This PR is partially motivated by IT-1967 and partially motivated by the need to inspect the bucket policy, which can only be done by IAM identities within the same account as the S3 bucket. As a result, my current sandbox role doesn't have access to the bucket policy. Since I have access to the viewer role in scicomp, I was thinking of granting access to my specific assumed-role at the resource/bucket level. If this works, then we can migrate others to using the same viewer role to administer/access the HTAN buckets. 