### PR TITLE
Fix s3-synapse-sync lambda path reference

### DIFF
--- a/config/prod/s3-synapse-sync.yaml
+++ b/config/prod/s3-synapse-sync.yaml
@@ -1,6 +1,6 @@
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.1/s3-synapse-sync.yaml"
 stack_name: "s3-synapse-sync"
 stack_tags:
   Department: "CompOnc"


### PR DESCRIPTION
The `s3-synapse-sync.yaml` is the generated lambda template from
the s3-synapse-sync[1] repo.  That generated lambda file is not
committed to git, it is generated then deployed to the
`admincentral_cf_bucket` therefore the template must be referenced
from that bucket.

[1] https://github.com/Sage-Bionetworks/s3-synapse-sync

