### PR TITLE
fix link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ execute the validations by running `pre-commit run --all-files`.
 
 ## Provision resources
 Instructions and workflow to auto provision and de-provision resources are
-in [Example PRs](https://github.com/Sage-Bionetworks/scicomp-provisioner/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+%22Example+PR%22)
+in [Example PRs](https://github.com/Sage-Bionetworks/scicomp-provisioner/pulls?q=is%3Apr+%22Example+PR%22+is%3Aclosed)
 
 ### Stack & config file names
 The value of a stack's `stack_name` parameter must match the config's file


### PR DESCRIPTION
Just a minor link change to make it easier to find the example PRs (they are all closed now).