### PR TITLE
external S3 bucket for syn23664726

### DIFF
--- a/config/prod/nf-syn23664726-s3.yaml
+++ b/config/prod/nf-syn23664726-s3.yaml
@@ -15,7 +15,6 @@ parameters:
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
-  
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket

--- a/config/prod/nf-syn23664726-s3.yaml
+++ b/config/prod/nf-syn23664726-s3.yaml
@@ -18,7 +18,8 @@ parameters:
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:sts::237179673806:assumed-role/AWSReservedSSO_Community-Manager_84cea7c897f3f843/robert.allaway@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org'
+    - 'arn:aws:iam::694704239947:root' ## Nebula Genomics access
 sceptre_user_data:
   SynapseIDs:
     - "3342573"

--- a/config/prod/nf-syn23664726-s3.yaml
+++ b/config/prod/nf-syn23664726-s3.yaml
@@ -1,7 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.8/templates/S3/synapse-external-bucket.j2"
 stack_name: "nf-syn23664726-s3"
 stack_tags:
   Department: "SCCE"

--- a/config/prod/nf-syn23664726-s3.yaml
+++ b/config/prod/nf-syn23664726-s3.yaml
@@ -9,21 +9,17 @@ stack_tags:
   OwnerEmail: 'robert.allaway@sagebionetworks.org'
   CostCenter: "NTAP NF Addendum 4 / 301100"
 parameters:
-  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "SCCE"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "neurofibromatosis"
-  # The resource owner
-  OwnerEmail: 'robert.allaway@sagebionetworks.org'
-
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.
-
+  # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
-  SynapseUserName: 'allawayr'
+  
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org'
+    - 'arn:aws:sts::237179673806:assumed-role/AWSReservedSSO_Community-Manager_84cea7c897f3f843/robert.allaway@sagebase.org'
+sceptre_user_data:
+  SynapseIDs:
+    - "3342573"

--- a/config/prod/nf-syn23664726-s3.yaml
+++ b/config/prod/nf-syn23664726-s3.yaml
@@ -1,0 +1,29 @@
+# Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
+stack_name: "nf-syn23664726-s3"
+stack_tags:
+  Department: "SCCE"
+  Project: "neurofibromatosis"
+  OwnerEmail: 'robert.allaway@sagebionetworks.org'
+  CostCenter: "NTAP NF Addendum 4 / 301100"
+parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "SCCE"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "neurofibromatosis"
+  # The resource owner
+  OwnerEmail: 'robert.allaway@sagebionetworks.org'
+
+  # The following parameters are only examples they are not required.
+  # You may omit them if you do not need to override the defaults.
+
+  # (Optional) true for read-write bucket, false (default) for read-only bucket
+  AllowWriteBucket: 'true'
+  # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
+  SynapseUserName: 'allawayr'
+  # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
+  GrantAccess:
+    - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
+    - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org'


### PR DESCRIPTION
I would like to provision an S3 bucket to store data for a project on synapse (syn23664726). 

I will need to add external contributors to this bucket, but I don't currently have their ARNs. Can I merge this PR and then update the file to update the bucket once I have the ARNs? 