### PR TITLE
Create nf-syn28545963-s3.yaml

### DIFF
--- a/config/prod/nf-syn28545963-s3.yaml
+++ b/config/prod/nf-syn28545963-s3.yaml
@@ -11,10 +11,8 @@ stack_tags:
 parameters:
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.
-  # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket

--- a/config/prod/nf-syn28545963-s3.yaml
+++ b/config/prod/nf-syn28545963-s3.yaml
@@ -18,8 +18,8 @@ parameters:
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org'
-    - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/sasha.scott@sagebase.org'
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/robert.allaway@sagebase.org'
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/sasha.scott@sagebase.org'
     - 'arn:aws:iam::184059545989:role/NCBI-CSVM-Service' #NCBI data delivery tool
     - 'arn:aws:iam::783971887864:role/NCBI-CSVM-Service' #NCBI data delivery tool
 sceptre_user_data:

--- a/config/prod/nf-syn28545963-s3.yaml
+++ b/config/prod/nf-syn28545963-s3.yaml
@@ -1,0 +1,28 @@
+# Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.8/templates/S3/synapse-external-bucket.j2"
+stack_name: "nf-syn28545963-s3"
+stack_tags:
+  Department: "SCCE"
+  Project: "neurofibromatosis"
+  OwnerEmail: 'robert.allaway@sagebionetworks.org'
+  CostCenter: "CTF NF Amend 11 / 304002"
+parameters:
+  # The following parameters are only examples they are not required.
+  # You may omit them if you do not need to override the defaults.
+  # (Optional) true (default) to encrypt bucket, false for no encryption
+  # (Optional) true for read-write bucket, false (default) for read-only bucket
+  AllowWriteBucket: 'true'
+  # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
+  # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
+  GrantAccess:
+    - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
+    - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/robert.allaway@sagebase.org'
+    - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/sasha.scott@sagebase.org'
+    - 'arn:aws:iam::184059545989:role/NCBI-CSVM-Service' #NCBI data delivery tool
+    - 'arn:aws:iam::783971887864:role/NCBI-CSVM-Service' #NCBI data delivery tool
+sceptre_user_data:
+  SynapseIDs:
+    - "3342573"
+    - "3441340"


### PR DESCRIPTION
This is to create an S3 bucket for a cloud delivery from NCBI for @ajs3nj.

The bucket needs to have permissions equivalent to this policy:

```
{
  "Id": "Policy1665001491261",
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "NCBIDataDeliveryAccess",
      "Action": "s3:*",
      "Effect": "Allow",
      "Resource": [
        "arn:aws:s3:::my-example-bucket",
        "arn:aws:s3:::my-example-bucket/*"
      ],
      "Principal": {
        "AWS": [
          "arn:aws:iam::184059545989:role/NCBI-CSVM-Service",
          "arn:aws:iam::783971887864:role/NCBI-CSVM-Service"
        ]
      }
    }
  ]
}
```
If we provision a bucket this way, will it have these permissions? It seems like this policy would give all s3:* permissions to the NCBI IAM users.