### PR TITLE
Update template for S3 buckets

### DIFF
--- a/config/prod/PsychENCODE-Globus-S3.yaml
+++ b/config/prod/PsychENCODE-Globus-S3.yaml
@@ -1,7 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.8/templates/S3/synapse-external-bucket.j2"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "PsychENCODE-Globus-S3"
 stack_tags:
   Department: "SysBio"

--- a/config/prod/nf-syn23664726-s3.yaml
+++ b/config/prod/nf-syn23664726-s3.yaml
@@ -1,7 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.8/templates/S3/synapse-external-bucket.j2"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "nf-syn23664726-s3"
 stack_tags:
   Department: "SCCE"

--- a/config/prod/nf-syn28545963-s3.yaml
+++ b/config/prod/nf-syn28545963-s3.yaml
@@ -1,7 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.8/templates/S3/synapse-external-bucket.j2"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "nf-syn28545963-s3"
 stack_tags:
   Department: "SCCE"

--- a/config/prod/recover-s3-bucket.yaml
+++ b/config/prod/recover-s3-bucket.yaml
@@ -1,7 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.4.8/templates/S3/synapse-external-bucket.j2"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "recover-s3-bucket"
 stack_tags:
   Department: "SysBio"


### PR DESCRIPTION
This updates the template for buckets in the scicomp-provisioner with changes
from https://github.com/Sage-Bionetworks/aws-infra/pull/359

depends on https://github.com/Sage-Bionetworks/aws-infra/pull/359