### PR TITLE
Create nf-syn23664726-s3-temp

### DIFF
--- a/config/prod/nf-syn23664726-s3-temp
+++ b/config/prod/nf-syn23664726-s3-temp
@@ -1,0 +1,27 @@
+# Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
+## This is a temporary bucket for troubleshooting nf-syn23664726-s3
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
+stack_name: "nf-syn23664726-s3-temp"
+stack_tags:
+  Department: "SCCE"
+  Project: "neurofibromatosis"
+  OwnerEmail: 'robert.allaway@sagebionetworks.org'
+  CostCenter: "NTAP NF Addendum 4 / 301100"
+parameters:
+  # The following parameters are only examples they are not required.
+  # You may omit them if you do not need to override the defaults.
+  # (Optional) true (default) to encrypt bucket, false for no encryption
+  # (Optional) true for read-write bucket, false (default) for read-only bucket
+  AllowWriteBucket: 'true'
+  # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
+  # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
+  GrantAccess:
+    - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/robert.allaway@sagebase.org'
+    - 'arn:aws:iam::694704239947:root' ## Nebula Genomics access
+    - 'arn:aws:iam::694704239947:user/giri' ## Nebula Genomics access
+sceptre_user_data:
+  SynapseIDs:
+    - "3342573"


### PR DESCRIPTION
This bucket is a temporary bucket to try and troubleshoot issues that Nebula Genomics is having with transferring a subset of files to `nf-syn23664726-s3`, we plan to try and transfer those files to this new bucket ( nf-syn23664726-s3-temp) and see if we can consolidate everything into nf-syn23664726-s3 on our end. After that this bucket can be deleted. 


[x] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`
