### PR TITLE
Handle no sceptre stack in CI deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ jobs:
         - pre-commit run --all-files
     - stage: deploy
       script:
-        - AWS_PROFILE=${AWS_PROFILE} travis_wait 30 sceptre launch prod --yes
+        - '[ "$(ls -A ./config/prod)" ] && AWS_PROFILE=${AWS_PROFILE} travis_wait 30 sceptre launch prod --prune --yes || echo "No Stacks"'


### PR DESCRIPTION
* Sceptre will fail if no config files are defined which should not be a failing condition in the context of CI deployments.  We add a check to deploy infra only if there are stacks to deploy to prevent a CI failure.
* Add --prune flag to automate the Sceptre deletion of stacks via the obsolete parameter[1]

Note: This is the same change as https://github.com/Sage-Bionetworks/sandbox-provisioner/pull/419

[1] https://docs.sceptre-project.org/latest/docs/faq.html#my-ci-cd-process-uses-sceptre-launch-how-do-i-delete-stacks-that-aren-t-needed-anymore

