### PR TITLE
[ETL-318] add access to recover bucket for recover glue job role

### DIFF
--- a/config/prod/recover-s3-bucket.yaml
+++ b/config/prod/recover-s3-bucket.yaml
@@ -20,6 +20,7 @@ parameters:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/meghasyam@sagebase.org'
     - 'arn:aws:iam::621233246578:role/EES3-RK-6A32F45B-RECOVER' # QA ARN role for Care Evolution
+    - 'arn:aws:iam::659375444835:role/glue-job-role-JobRole-XL4YIFI6POVV' # Recover glue job role access
 sceptre_user_data:
   SynapseIDs:
     - "3357179" # Megha's synapse profileID


### PR DESCRIPTION
**Purpose:** To complete [ETL-318](https://sagebionetworks.jira.com/browse/ETL-318). The role policy and permissions can be found here: [recover/main/templates/glue-job-role.yaml](https://github.com/Sage-Bionetworks/recover/blob/main/templates/glue-job-role.yaml#L70-L80)

PR Checklist:
[X] Clearly explain your change with a descriptive commit message
[X] Setup pre-commit and run the validators (info in README.md)
    To validate files run: `pre-commit run --all-files`


[ETL-318]: https://sagebionetworks.jira.com/browse/ETL-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ