### PR TITLE
grant bucket access

### DIFF
--- a/config/prod/usage-statistics-S3.yaml
+++ b/config/prod/usage-statistics-S3.yaml
@@ -20,6 +20,7 @@ parameters:
   GrantAccess:
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/phil.snyder@sagebase.org'
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/larsson.omberg@sagebase.org'
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/abby.vanderlinden@sagebase.org'
 
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.


### PR DESCRIPTION
I added my ARN to the `grantAccess` list in order to get access to this bucket. I believe it contains files related to data usage stats that we need for the AD Portal. Larsson is listed as the bucket owner but has not accessed it himself; he says it's fine for me to be added. 
