### PR TITLE
Disable ACLs on usage-statistics bucket

### DIFF
--- a/config/prod/usage-statistics-S3.yaml
+++ b/config/prod/usage-statistics-S3.yaml
@@ -1,7 +1,7 @@
 # For storage of files related to usage statistics reporting
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/S3/synapse-external-bucket.j2"
 stack_name: "usage-statistics-S3"
 stack_tags:
   Department: "SysBio"
@@ -10,13 +10,6 @@ stack_tags:
   CostCenter: "NO PROGRAM / 000000"
 
 parameters:
-  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "SysBio"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "DataEngineering"
-  # The resource owner
-  OwnerEmail: 'larsson.omberg@sagebase.org'
-
   GrantAccess:
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/phil.snyder@sagebase.org'
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/larsson.omberg@sagebase.org'


### PR DESCRIPTION
There were issues with access to the usage-statistics bucket due to ACLs being enabled on that bucket.  AWS now advises using bucket policies for access instead of ACLs[1].  Our newer cloudformation template deploys S3 with ACLs turned off. This configures the bucket with settings from our updated cloudformation template.

[1] https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html

