### PR TITLE
Update pre-commit hook to new endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     -    id: check-stack-names
     -    id: check-stack-tag-values
          args: [--tag=CostCenter,
-                --file=https://finops-api.sageit.org/tags,
+                --file=https://mips-api.finops.sageit.org/tags,
                 --file=DeprecatedProgramCodes.json,
                 --exclude=Other / 000001
          ]


### PR DESCRIPTION
The mips-api lambda is migrating to a new host name.
