### PR TITLE
Create ec2 and alb for miniDREAM 2023

### DIFF
--- a/config/prod/minidream-rstudio-2023-ec2-alb.yaml
+++ b/config/prod/minidream-rstudio-2023-ec2-alb.yaml
@@ -1,0 +1,23 @@
+# Provision a public load balancer in front of private miniDREAM EC2
+# Based on the PR here: https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/504/files
+
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.6.83/managed-alb-https-v2.yaml"
+stack_name: "minidream-rstudio-2023-ec2-alb"
+dependencies:
+  - "prod/minidream-rstudio-2023-ec2.yaml"
+parameters:
+  Department: "SCCE"
+  Project: "MC2 Center"
+  OwnerEmail: "verena.chung@sagebase.org"
+  Ec2InstanceId: !stack_output_external "minidream-rstudio-2023-ec2::Ec2InstanceId"
+  SSLCertificateIdArn: "arn:aws:acm:us-east-1:055273631518:certificate/992c2d49-579a-465e-beff-1a08c284f7db"
+  VpcId: "vpc-e66bd19d"   # computevpc
+  AppPort: "443"          # nginx reverse proxy
+  Subnets: "subnet-21a68d7c,subnet-4f3e2b2b,subnet-77d1e458"  # public subnets
+stack_tags:
+  CostCenter: "Multi-Consortia Coordinating Center (MC2 Center) / 123100"
+# After deployment, Ec2SecurityGroup must be manually attached to the EC2 referenced by Ec2InstanceId:
+# https://github.com/Sage-Bionetworks/aws-infra/blob/v0.2.13/templates/managed-alb-https-v2.yaml#L5-L8
+# Also, update DNS for minidream.synapse.org to point to this ALB once deployed.

--- a/config/prod/minidream-rstudio-2023-ec2.yaml
+++ b/config/prod/minidream-rstudio-2023-ec2.yaml
@@ -1,0 +1,28 @@
+# Provision an EC2 instance for hosting miniDREAM RStudio server
+# Based on the PR here: https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/504/files
+
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.6.83/EC2/jc-ec2-linux.j2"
+stack_name: "minidream-rstudio-2023-ec2"
+
+sceptre_user_data:
+  Distro: "ubuntu"
+  OpenPorts: ["443"]  # On a private subnet (default)
+parameters:
+  KeyName: "scicomp"
+  VpcName: "computevpc"
+  AMIId: "ami-0a3c3e0cb6ae0cc6c"  # packer-base-ubuntu-bionic-v1.0.10
+  InstanceType: "r5a.8xlarge"     # 32 vCPUs / 256 GiB
+  VolumeSize: "450"
+  BackupEc2: "true"
+  SnapshotCount: "3"
+  JcUserId: "verena.chung@sagebase.org"
+  JcConnectKey: !ssm "/infra/JcConnectKey"
+  JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
+  JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
+stack_tags:
+  Department: "SCCE"
+  Project: "MC2 Center"
+  OwnerEmail: "verena.chung@sagebase.org"
+  CostCenter: "Multi-Consortia Coordinating Center (MC2 Center) / 123100"

--- a/config/prod/minidream-rstudio-2023-ec2.yaml
+++ b/config/prod/minidream-rstudio-2023-ec2.yaml
@@ -14,7 +14,7 @@ parameters:
   VpcName: "computevpc"
   AMIId: "ami-0a3c3e0cb6ae0cc6c"  # packer-base-ubuntu-bionic-v1.0.10
   InstanceType: "r5a.8xlarge"     # 32 vCPUs / 256 GiB
-  VolumeSize: "450"
+  VolumeSize: "500"
   BackupEc2: "true"
   SnapshotCount: "3"
   JcUserId: "verena.chung@sagebase.org"


### PR DESCRIPTION
Setting up a stack to run miniDREAM this year for about 16 students. Similar to [last year](https://github.com/Sage-Bionetworks/scicomp-provisioner/pull/522), the stack is composed of a high-memory EC2 instance in a private subnet behind by a public load balancer (both using existing aws-infra templates), which will be used to provide a RStudio environment for students taking the miniDREAM courses.

This PR was built using #522 as a reference.