### PR TITLE
Remove invalid chars in CostCenter tag

### DIFF
--- a/DeprecatedProgramCodes.json
+++ b/DeprecatedProgramCodes.json
@@ -11,5 +11,6 @@
   "PECDCC-UMass / 106000",
   "Psorcast Pscrosis App / 613500",
   "TREAT AD - Emory / 121100",
-  "Washington Univ - DIAN / 403500"
+  "Washington Univ - DIAN / 403500",
+  "Multi-Consortia Coordinating Center MC2 Center / 123100"
 ]

--- a/config/prod/minidream-rstudio-2023-ec2-alb.yaml
+++ b/config/prod/minidream-rstudio-2023-ec2-alb.yaml
@@ -17,7 +17,7 @@ parameters:
   AppPort: "443"          # nginx reverse proxy
   Subnets: "subnet-21a68d7c,subnet-4f3e2b2b,subnet-77d1e458"  # public subnets
 stack_tags:
-  CostCenter: "Multi-Consortia Coordinating Center (MC2 Center) / 123100"
+  CostCenter: "Multi-Consortia Coordinating Center MC2 Center / 123100"
 # After deployment, Ec2SecurityGroup must be manually attached to the EC2 referenced by Ec2InstanceId:
 # https://github.com/Sage-Bionetworks/aws-infra/blob/v0.2.13/templates/managed-alb-https-v2.yaml#L5-L8
 # Also, update DNS for minidream.synapse.org to point to this ALB once deployed.

--- a/config/prod/minidream-rstudio-2023-ec2.yaml
+++ b/config/prod/minidream-rstudio-2023-ec2.yaml
@@ -25,4 +25,4 @@ stack_tags:
   Department: "SCCE"
   Project: "MC2 Center"
   OwnerEmail: "verena.chung@sagebase.org"
-  CostCenter: "Multi-Consortia Coordinating Center (MC2 Center) / 123100"
+  CostCenter: "Multi-Consortia Coordinating Center MC2 Center / 123100"


### PR DESCRIPTION
AWS does not allow parenthesis characters in Tags.
```
validation error detected: Value 'Multi-Consortia Coordinating Center (MC2 Center) / 123100'
at 'tags.3.member.value' failed to satisfy constraint: Member must satisfy regular expression
pattern: [\p{L}\p{Z}\p{N}_.:/=+\-@]*
```

Remove parenthesis to allow provisioning the resource
for now.  We will need to figure out a more general
solution for this problem.
