### PR TITLE
restore check for quoted string in yaml

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -27,3 +27,11 @@ rules:
   truthy: disable
   new-line-at-end-of-file:
     level: warning
+  quoted-strings:
+    ignore: |
+      .yamllint
+      .pre-commit-config.yaml
+      .travis.yml
+      config/config.yaml
+      templates/
+      .github/


### PR DESCRIPTION
Restore the yaml quote string check that was removed in PR #567 We want to make sure all values in sceptre config files are quoted.
