### PR TITLE
Remove region restriction for TESLA bucket

### DIFF
--- a/config/prod/TESLA-download-bucket.yaml
+++ b/config/prod/TESLA-download-bucket.yaml
@@ -29,7 +29,7 @@ parameters:
   # Data transfers within the same region between AWS resources are free.
   # true to restrict downloading files from this bucket to only AWS resources (e.g. EC2 , Lambda) within the same region as this bucket.
   # This will not allow even the owner of the bucket to download objects in this bucket when not using an AWS resource in the same region!
-  SameRegionResourceAccessToBucket: "true"
+  SameRegionResourceAccessToBucket: "false"
 
   # (Optional) Allow accounts, groups, and users to access bucket. (default is no access).
   GrantAccess:


### PR DESCRIPTION
The template used to provision the TESLA bucket is old and is setup to deploy a lambda with python 3.6. AWS no longer supports that old python version so it fails when we attempt to deploy the bucket with the following message..

```
Resource handler returned message: "The runtime parameter of python3.6 is no longer supported
for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.9)
while creating or updating functions.
```

We need to temporarily remove region restriction, update the templates then hopefully restore region restriction.

