### PR TITLE
Remove unneeded parameter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
          args: [--tag=CostCenter,
                 --file=https://mips-api.finops.sageit.org/tags,
                 --file=DeprecatedProgramCodes.json,
-                --exclude=Other / 000001
          ]
 -   repo: https://github.com/sirosen/check-jsonschema
     rev: 0.22.0


### PR DESCRIPTION
The mips-api lambda no longer includes an Other tag by default, so we don't need to ignore it.
