### PR TITLE
update instance type and volume size

### DIFF
--- a/config/prod/minidream-rstudio-2023-ec2.yaml
+++ b/config/prod/minidream-rstudio-2023-ec2.yaml
@@ -13,8 +13,8 @@ parameters:
   KeyName: "scicomp"
   VpcName: "computevpc"
   AMIId: "ami-0a3c3e0cb6ae0cc6c"  # packer-base-ubuntu-bionic-v1.0.10
-  InstanceType: "r5a.8xlarge"     # 32 vCPUs / 256 GiB
-  VolumeSize: "500"
+  InstanceType: "r5a.12xlarge"    # 48 vCPUs / 384 GiB
+  VolumeSize: "1000"
   BackupEc2: "true"
   SnapshotCount: "3"
   JcUserId: "verena.chung@sagebase.org"


### PR DESCRIPTION
We are planning on adding about 10 more students to the miniDREAM course, bringing the total number of students to about 26.  To better accommodate the new classroom size, I want to upgrade the instance type and volume size to be the same as last year's, which supported around 27 students without issues.