### PR TITLE
[IT-2768] Update role name for CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-1
-          role-to-assume: arn:aws:iam::055273631518:role/sagebase-github-oidc-sage-ProviderRolescicompprovi-BWN39S0CL6IZ
+          role-to-assume: arn:aws:iam::055273631518:role/sagebase-github-oidc-sage-bionetworks-scicomp-provisioner
           role-session-name: GitHubActions-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: 1800
       - name: 'Sceptre Deploy'


### PR DESCRIPTION
The CI role names to assume will change due to PR
Sage-Bionetworks-IT/organizations-infra#859. update to the new role names

depends on Sage-Bionetworks-IT/organizations-infra#859
