### PR TITLE
[IT-2851] Roll back to hard-coded files in aws-infra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,8 @@ repos:
     -    id: check-stack-names
     -    id: check-stack-tag-values
          args: [--tag=CostCenter,
-                --file=https://mips-api.finops.sageit.org/tags,
+                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/tags/SageFinancialProgramCodes.json,
+                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/tags/SageFinancialProgramCodesOther.json,
                 --file=DeprecatedProgramCodes.json,
          ]
 -   repo: https://github.com/sirosen/check-jsonschema

--- a/DeprecatedProgramCodes.json
+++ b/DeprecatedProgramCodes.json
@@ -1,4 +1,5 @@
 [
+  "No Program / 000000",
   "BMGF-Ki / 30144",
   "Genie-AACR / 312000",
   "CTF NF Amend 11 / 304002",


### PR DESCRIPTION
MIP Cloud has effectively disabled lambda-mips-api from logging in, roll back to the hard-coded files in aws-infra.

Also add an alternative capitalization for No Program since the hard-coded files have NO PROGRAM.