### PR TITLE
[IT-2703] Remove Project and Department tags

### DIFF
--- a/config/prod/AMP-Emory-Bucket.yaml
+++ b/config/prod/AMP-Emory-Bucket.yaml
@@ -1,26 +1,18 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
 stack_name: "AMP-Emory-Bucket"
 stack_tags:
-  Department: "SysBio"
-  Project: "AMP-Emory"
   OwnerEmail: "ampadportal@sagebase.org"
   CostCenter: "TREAT AD - Emory / 121100"
 parameters:
-  # The Sage deparment for this resource
-  Department: "SysBio"
-  # The Sage project this resource will be used for
-  Project: "AMP-Emory"
   # true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
   # Synapse username
   SynapseUserName: "yooree"
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "true"
-  # Bucket owner's email address
-  OwnerEmail: 'ampadportal@sagebase.org'
   # Allow accounts, groups, and users to access bucket.
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'

--- a/config/prod/AMP-Emory-Bucket.yaml
+++ b/config/prod/AMP-Emory-Bucket.yaml
@@ -1,18 +1,24 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "AMP-Emory-Bucket"
 stack_tags:
   OwnerEmail: "ampadportal@sagebase.org"
   CostCenter: "TREAT AD - Emory / 121100"
 parameters:
+  # The Sage deparment for this resource
+  Department: "SysBio"
+  # The Sage project this resource will be used for
+  Project: "AMP-Emory"
   # true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
   # Synapse username
   SynapseUserName: "yooree"
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "true"
+  # Bucket owner's email address
+  OwnerEmail: 'ampadportal@sagebase.org'
   # Allow accounts, groups, and users to access bucket.
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'

--- a/config/prod/PsychENCODE-Globus-S3.yaml
+++ b/config/prod/PsychENCODE-Globus-S3.yaml
@@ -4,8 +4,6 @@ template:
   url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "PsychENCODE-Globus-S3"
 stack_tags:
-  Department: "SysBio"
-  Project: "PsychENCODE"
   OwnerEmail: "dan.lu@sagebase.org"
   CostCenter: "PECDCC-UMass / 106000"
 parameters:

--- a/config/prod/TESLA-download-bucket.yaml
+++ b/config/prod/TESLA-download-bucket.yaml
@@ -2,23 +2,15 @@
 # http://docs.synapse.org/articles/custom_storage_location.html
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/v0.2.7/s3-bucket-v2.j2"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket-v2.j2"
 stack_name: "TESLA-download-bucket"
 stack_tags:
-  Department: "CompOnc"
-  Project: "TESLA"
   OwnerEmail: "james.eddy@sagebase.org"
   CostCenter: "No Program / 000000"
 sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
   SynapseIDs: ["2223305"]  # James Eddy
 parameters:
-  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "CompOnc"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "TESLA"
-  # The resource owner
-  OwnerEmail: "james.eddy@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
 

--- a/config/prod/TESLA-download-bucket.yaml
+++ b/config/prod/TESLA-download-bucket.yaml
@@ -2,7 +2,7 @@
 # http://docs.synapse.org/articles/custom_storage_location.html
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket-v2.j2"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/v0.2.7/s3-bucket-v2.j2"
 stack_name: "TESLA-download-bucket"
 stack_tags:
   OwnerEmail: "james.eddy@sagebase.org"
@@ -11,6 +11,12 @@ sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
   SynapseIDs: ["2223305"]  # James Eddy
 parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "CompOnc"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "TESLA"
+  # The resource owner
+  OwnerEmail: "james.eddy@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
 

--- a/config/prod/VEOIBD-S3-USA.yaml
+++ b/config/prod/VEOIBD-S3-USA.yaml
@@ -4,8 +4,6 @@ template:
   url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "VEOIBD-S3-USA"
 stack_tags:
-  Department: "SysBio"
-  Project: "veo-ibd"
   OwnerEmail: "dan.lu@sagebase.org"
   CostCenter: "Helmsley VEOIBD / 314100"
 parameters:

--- a/config/prod/aacr-interactome-s3website-new.yaml
+++ b/config/prod/aacr-interactome-s3website-new.yaml
@@ -1,20 +1,12 @@
 # Provision a S3 static website for AACR Interactome
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-s3WebCloudfront.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/managed-s3WebCloudfront.yaml"
 stack_name: "aacr-interactome-s3website-new"
 stack_tags:
-  Department: "CompOnc"
-  Project: "AACR"
   OwnerEmail: "xindi.guo@sagebase.org"
   CostCenter: "Genie-AACR / 312000"
 parameters:
-  # The department for this resource (i.e. CompOnc, SysBio, Platform, etc..)
-  Department: "CompOnc"
-  # The project for this resource (i.e. NTAP, BSMN, DREAM, etc..)
-  Project: "AACR"
-  # The resource owner's email address
-  OwnerEmail: "xindi.guo@sagebase.org"
   # Domain name for your website (sagebionetworks.org)
   DomainName: "sagebionetworks.org"
   # The sub domain name e.g. ('mysite' in mysite.sagebionetworks.org)

--- a/config/prod/amp-mayo-sinai.yaml
+++ b/config/prod/amp-mayo-sinai.yaml
@@ -1,12 +1,19 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "amp-mayo-sinai"
 stack_tags:
   OwnerEmail: 'william.poehlman@sagebase.org'
   CostCenter: "Model AD-IU / 116000"
 parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "NDR"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "amp-ad-wgs"
+  # The resource owner
+  OwnerEmail: 'william.poehlman@sagebase.org'
+
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.
 

--- a/config/prod/amp-mayo-sinai.yaml
+++ b/config/prod/amp-mayo-sinai.yaml
@@ -1,21 +1,12 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
 stack_name: "amp-mayo-sinai"
 stack_tags:
-  Department: "NDR"
-  Project: "amp-ad-wgs"
   OwnerEmail: 'william.poehlman@sagebase.org'
   CostCenter: "Model AD-IU / 116000"
 parameters:
-  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "NDR"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "amp-ad-wgs"
-  # The resource owner
-  OwnerEmail: 'william.poehlman@sagebase.org'
-
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.
 

--- a/config/prod/dian-prod-hm-migration-s3.yaml
+++ b/config/prod/dian-prod-hm-migration-s3.yaml
@@ -2,7 +2,7 @@
 # http://docs.synapse.org/articles/custom_storage_location.html
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket-v2.j2"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.19/s3-bucket-v2.j2"
 stack_name: "dian-prod-hm-migration-s3"
 stack_tags:
   OwnerEmail: "synapse-service+dian-prod@sagebase.org"
@@ -11,6 +11,12 @@ sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
   SynapseIDs: ["3425758"]  #synapse-service-dian-prod@synapse.org
 parameters:
+  # The Sage department (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "Platform"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "DIAN"
+  # The resource owner
+  OwnerEmail: "synapse-service+dian-prod@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
 

--- a/config/prod/dian-prod-hm-migration-s3.yaml
+++ b/config/prod/dian-prod-hm-migration-s3.yaml
@@ -2,23 +2,15 @@
 # http://docs.synapse.org/articles/custom_storage_location.html
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.19/s3-bucket-v2.j2"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket-v2.j2"
 stack_name: "dian-prod-hm-migration-s3"
 stack_tags:
-  Department: "Platform"
-  Project: "DIAN"
   OwnerEmail: "synapse-service+dian-prod@sagebase.org"
   CostCenter: "Washington Univ - DIAN / 403500"
 sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
   SynapseIDs: ["3425758"]  #synapse-service-dian-prod@synapse.org
 parameters:
-  # The Sage department (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "Platform"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "DIAN"
-  # The resource owner
-  OwnerEmail: "synapse-service+dian-prod@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
 

--- a/config/prod/dian-uat-hm-migration-s3.yaml
+++ b/config/prod/dian-uat-hm-migration-s3.yaml
@@ -2,23 +2,15 @@
 # http://docs.synapse.org/articles/custom_storage_location.html
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.19/s3-bucket-v2.j2"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket-v2.j2"
 stack_name: "dian-uat-hm-migration-s3"
 stack_tags:
-  Department: "Platform"
-  Project: "DIAN"
   OwnerEmail: "synapse-service+dian-prod@sagebase.org"
   CostCenter: "Washington Univ - DIAN / 403500"
 sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
   SynapseIDs: ["3425757"]  #synapse-service-dian-uat@synapse.org
 parameters:
-  # The Sage department (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "Platform"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "DIAN"
-  # The resource owner
-  OwnerEmail: "synapse-service+dian-uat@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
 

--- a/config/prod/dian-uat-hm-migration-s3.yaml
+++ b/config/prod/dian-uat-hm-migration-s3.yaml
@@ -2,7 +2,7 @@
 # http://docs.synapse.org/articles/custom_storage_location.html
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket-v2.j2"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.19/s3-bucket-v2.j2"
 stack_name: "dian-uat-hm-migration-s3"
 stack_tags:
   OwnerEmail: "synapse-service+dian-prod@sagebase.org"
@@ -11,6 +11,12 @@ sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
   SynapseIDs: ["3425757"]  #synapse-service-dian-uat@synapse.org
 parameters:
+  # The Sage department (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "Platform"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "DIAN"
+  # The resource owner
+  OwnerEmail: "synapse-service+dian-uat@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
 

--- a/config/prod/ecmonsen-emorypipeline-ci.yaml
+++ b/config/prod/ecmonsen-emorypipeline-ci.yaml
@@ -2,14 +2,5 @@ template:
   path: "ecmonsen-emorypipeline-ci.yaml"
 stack_name: "ecmonsen-emorypipeline-ci"
 stack_tags:
-  Department: "SysBio"
-  Project: "amp-ad"
   OwnerEmail: "tess.thyer@sagebase.org"
   CostCenter: "NIA AMP-AD CC / 101500"
-parameters:
-  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "SysBio"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "amp-ad"
-  # The resource owner
-  OwnerEmail: "tess.thyer@sagebase.org"

--- a/config/prod/ecmonsen-emorypipeline-lambda.yaml
+++ b/config/prod/ecmonsen-emorypipeline-lambda.yaml
@@ -4,8 +4,6 @@ template:
 # Note stack name must be 43 chars or less, otherwise bucket name is too long and CloudFormation fails
 stack_name: "ecmonsen-emorypipeline-lambda"
 stack_tags:
-  Department: "SysBio"
-  Project: "amp-ad"
   OwnerEmail: "tess.thyer@sagebase.org"
   CostCenter: "NIA AMP-AD CC / 101500"
 dependencies:

--- a/config/prod/gates-ki-001.yaml
+++ b/config/prod/gates-ki-001.yaml
@@ -1,26 +1,18 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
 stack_name: "gates-ki-001"
 stack_tags:
-  Department: "SysBio"
-  Project: "GatesKi"
   OwnerEmail: 'larsson.omberg@sagebase.org'
   CostCenter: "BMGF-Ki / 30144"
 parameters:
-  # The Sage deparment for this resource
-  Department: "SysBio"
-  # The Sage project this resource will be used for
-  Project: "GatesKi"
   # true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
   # Synapse username
   SynapseUserName: "gates-ki-service"
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "true"
-  # Bucket owner's email address
-  OwnerEmail: 'larsson.omberg@sagebase.org'
   # Allow accounts, groups, and users to access bucket.
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'

--- a/config/prod/gates-ki-001.yaml
+++ b/config/prod/gates-ki-001.yaml
@@ -1,18 +1,24 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "gates-ki-001"
 stack_tags:
   OwnerEmail: 'larsson.omberg@sagebase.org'
   CostCenter: "BMGF-Ki / 30144"
 parameters:
+  # The Sage deparment for this resource
+  Department: "SysBio"
+  # The Sage project this resource will be used for
+  Project: "GatesKi"
   # true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: "true"
   # Synapse username
   SynapseUserName: "gates-ki-service"
   # true to encrypt bucket, false (default) for no encryption
   EncryptBucket: "true"
+  # Bucket owner's email address
+  OwnerEmail: 'larsson.omberg@sagebase.org'
   # Allow accounts, groups, and users to access bucket.
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'

--- a/config/prod/htan-dcc-center-a.yaml
+++ b/config/prod/htan-dcc-center-a.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-center-a"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-chop"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-dfci"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-duke"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-hms"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-msk"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-ohsu"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-pcapp"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-stanford"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tma-tnp"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tnp-sardana"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -5,8 +5,6 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-vanderbilt"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/htan-synapse-sync-kms-key.yaml
+++ b/config/prod/htan-synapse-sync-kms-key.yaml
@@ -2,8 +2,6 @@ template:
   path: "htan-synapse-sync-kms-key.yaml"
 stack_name: "htan-synapse-sync-kms-key"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 parameters:

--- a/config/prod/mep-lincs-s3.yaml
+++ b/config/prod/mep-lincs-s3.yaml
@@ -5,20 +5,12 @@
 
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
 stack_name: "mep-lincs-s3"
 stack_tags:
-  Department: "SysBio"
-  Project: "MEP-LINCS"
   OwnerEmail: "larsson.omberg@sagebase.org"
   CostCenter: "No Program / 000000"
 parameters:
-  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "SysBio"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "MEP-LINCS"
-  # The resource owner
-  OwnerEmail: "larsson.omberg@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
   SynapseUserName: 'larssono'

--- a/config/prod/mep-lincs-s3.yaml
+++ b/config/prod/mep-lincs-s3.yaml
@@ -5,12 +5,18 @@
 
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "mep-lincs-s3"
 stack_tags:
   OwnerEmail: "larsson.omberg@sagebase.org"
   CostCenter: "No Program / 000000"
 parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "SysBio"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "MEP-LINCS"
+  # The resource owner
+  OwnerEmail: "larsson.omberg@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
   SynapseUserName: 'larssono'

--- a/config/prod/nf-syn23664726-s3.yaml
+++ b/config/prod/nf-syn23664726-s3.yaml
@@ -4,8 +4,6 @@ template:
   url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "nf-syn23664726-s3"
 stack_tags:
-  Department: "SCCE"
-  Project: "neurofibromatosis"
   OwnerEmail: 'robert.allaway@sagebionetworks.org'
   CostCenter: "NTAP NF Addendum 4 / 301100"
 parameters:

--- a/config/prod/nf-syn28545963-s3.yaml
+++ b/config/prod/nf-syn28545963-s3.yaml
@@ -4,8 +4,6 @@ template:
   url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "nf-syn28545963-s3"
 stack_tags:
-  Department: "SCCE"
-  Project: "neurofibromatosis"
   OwnerEmail: 'robert.allaway@sagebionetworks.org'
   CostCenter: "CTF NF Amend 11 / 304002"
 parameters:

--- a/config/prod/psorcast-ec2.yaml
+++ b/config/prod/psorcast-ec2.yaml
@@ -4,8 +4,6 @@ template:
   url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/EC2/jc-ec2-linux.j2"
 stack_name: "psorcast-ec2"
 stack_tags:
-  Department: "SysBio"
-  Project: "psorcast"
   OwnerEmail: "vijay.yadav@sagebase.org"
   CostCenter: "Psorcast Pscrosis App / 613500"
 sceptre_user_data:

--- a/config/prod/recover-s3-bucket.yaml
+++ b/config/prod/recover-s3-bucket.yaml
@@ -4,8 +4,6 @@ template:
   url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.5.0/templates/S3/synapse-external-bucket.j2"
 stack_name: "recover-s3-bucket"
 stack_tags:
-  Department: "SysBio"
-  Project: "RECOVER"
   OwnerEmail: 'meghasyam@sagebase.org'
   CostCenter: "MGH RECOVER / 122500"
 parameters:

--- a/config/prod/s3-synapse-sync.yaml
+++ b/config/prod/s3-synapse-sync.yaml
@@ -3,8 +3,6 @@ template:
   url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/v1.6.1/s3-synapse-sync.yaml"
 stack_name: "s3-synapse-sync"
 stack_tags:
-  Department: "CompOnc"
-  Project: "HTAN"
   OwnerEmail: "bruno.grande@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:

--- a/config/prod/shinyserver-pro-prod-alb-v2.yaml
+++ b/config/prod/shinyserver-pro-prod-alb-v2.yaml
@@ -1,21 +1,12 @@
 # Provision a load balancer for shiny.synapse.org
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-alb-https-v2.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/managed-alb-https-v2.yaml"
 stack_name: "shinyserver-pro-prod-alb-v2"
 stack_tags:
-  Department: "Platform"
-  Project: "Infrastucture"
   OwnerEmail: "x.schildwachter@sagebase.org"
   CostCenter: "Platform Infrastructure / 990300"
 parameters:
-  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "Platform"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "Infrastucture"
-  # The resource owner
-  OwnerEmail: "x.schildwachter@sagebase.org"
-
   # load balancer configs
   Ec2InstanceId: !stack_output_external "shinyserver-pro-prod::Ec2InstanceId"
   SSLCertificateIdArn: "arn:aws:acm:us-east-1:055273631518:certificate/992c2d49-579a-465e-beff-1a08c284f7db"

--- a/config/prod/shinyserver-pro-prod.yaml
+++ b/config/prod/shinyserver-pro-prod.yaml
@@ -4,8 +4,6 @@ template:
   url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.4.0/EC2/jc-ec2-linux.j2"
 stack_name: "shinyserver-pro-prod"
 stack_tags:
-  Department: "Platform"
-  Project: "Infrastucture"
   OwnerEmail: "x.schildwachter@sagebase.org"
   CostCenter: "Platform Infrastructure / 990300"
 

--- a/config/prod/usage-statistics-S3.yaml
+++ b/config/prod/usage-statistics-S3.yaml
@@ -4,8 +4,6 @@ template:
   url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.7/templates/S3/synapse-external-bucket.j2"
 stack_name: "usage-statistics-S3"
 stack_tags:
-  Department: "SysBio"
-  Project: "DataEngineering"
   OwnerEmail: 'larsson.omberg@sagebase.org'
   CostCenter: "No Program / 000000"
 

--- a/config/prod/veoibd-s3.yaml
+++ b/config/prod/veoibd-s3.yaml
@@ -2,12 +2,18 @@
 # http://docs.synapse.org/articles/custom_storage_location.html
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "veoibd-s3"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
   CostCenter: "No Program / 000000"
 parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "SysBio"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "VEO-IBD"
+  # The resource owner
+  OwnerEmail: "thomas.yu@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
 

--- a/config/prod/veoibd-s3.yaml
+++ b/config/prod/veoibd-s3.yaml
@@ -2,20 +2,12 @@
 # http://docs.synapse.org/articles/custom_storage_location.html
 template:
   type: "http"
-  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.7.3/s3-bucket.yaml"
 stack_name: "veoibd-s3"
 stack_tags:
-  Department: "SysBio"
-  Project: "VEO-IBD"
   OwnerEmail: "thomas.yu@sagebase.org"
   CostCenter: "No Program / 000000"
 parameters:
-  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-  Department: "SysBio"
-  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-  Project: "VEO-IBD"
-  # The resource owner
-  OwnerEmail: "thomas.yu@sagebase.org"
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
 

--- a/templates/ecmonsen-emorypipeline-ci.yaml
+++ b/templates/ecmonsen-emorypipeline-ci.yaml
@@ -1,26 +1,6 @@
 Description: Setup service account and roles for Emory pipeline lambda
 AWSTemplateFormatVersion: 2010-09-09
 
-Parameters:
-  Department:
-    Description: 'The department for this resource'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'SysBio'
-  Project:
-    Description: 'The name of the project that this resource is used for'
-    Type: String
-    AllowedPattern: '^\S*$'
-    ConstraintDescription: 'Must be string with no spaces'
-    Default: 'AMP-AD'
-  OwnerEmail:
-    Description: 'Email address of the owner of this resource'
-    Type: String
-    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
-    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
-    Default: 'eva.monsen@sagebase.org'
-
 Resources:
   # !! IMPORTANT !! - AWS API will refuse to remove users that have attached resources.
   # Therefore you must do the following before deleting them from this file:
@@ -29,14 +9,6 @@ Resources:
   # 2. Detach the user from all groups.
   LambdaArtifactsBucket:
     Type: 'AWS::S3::Bucket'
-    Properties:
-      Tags:
-        - Key: "Department"
-          Value: !Ref Department
-        - Key: "Project"
-          Value: !Ref Project
-        - Key: "OwnerEmail"
-          Value: !Ref OwnerEmail
 
   # Allow public read on lambda bucket so that build users can read from it
   # Same as bootstrap bucket https://github.com/Sage-Bionetworks/aws-infra/blob/206c4b0ecafc8966561a2bfb3adfeb9ffa872048/templates/bootstrap.yaml#L66


### PR DESCRIPTION
We don't use the Project or Department tags for cost-tracking, remove them from stack tags and update some templates to versions that don't require these unused tags.

Also remove the OwnerEmail parameter, relying on
tag propagation from the stack tag.
