### PR TITLE
Revert "[IT-2851] Roll back to hard-coded files in aws-infra (#585)"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,7 @@ repos:
     -    id: check-stack-names
     -    id: check-stack-tag-values
          args: [--tag=CostCenter,
-                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/tags/SageFinancialProgramCodes.json,
-                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.6.9/templates/tags/SageFinancialProgramCodesOther.json,
+                --file=https://mips-api.finops.sageit.org/tags,
                 --file=DeprecatedProgramCodes.json,
          ]
 -   repo: https://github.com/sirosen/check-jsonschema

--- a/DeprecatedProgramCodes.json
+++ b/DeprecatedProgramCodes.json
@@ -1,5 +1,4 @@
 [
-  "No Program / 000000",
   "BMGF-Ki / 30144",
   "Genie-AACR / 312000",
   "CTF NF Amend 11 / 304002",


### PR DESCRIPTION
MIP Support has resolved the issue preventing the lambda from logging in, return to using it in our pre-commit check.

This reverts commit f6c343e7f6034cd13b74d4cb4231cdf5402c2d1a.