### PR TITLE
[IT-2300] Fix AWS security groups in Scicomp

### DIFF
--- a/config/prod/s3-synapse-sync.yaml
+++ b/config/prod/s3-synapse-sync.yaml
@@ -8,6 +8,7 @@ stack_tags:
 dependencies:
   - "prod/htan-synapse-sync-kms-key.yaml"
 parameters:
+  CIDR: "10.50.0.0/16"
   BucketVariables: >-
     {
       "htan-dcc-center-a":{"SynapseProjectId":"syn22343754"},


### PR DESCRIPTION
Only allow access to s3 sync instances from the sage VPN

