### PR TITLE
[IT-2923] Enable bucket lifecycle

### DIFF
--- a/config/prod/AMP-Emory-Bucket.yaml
+++ b/config/prod/AMP-Emory-Bucket.yaml
@@ -23,3 +23,5 @@ parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/phil.snyder@sagebase.org'
+  EnableDataLifeCycle: "true"
+  LifecycleDataStorageClass: "INTELLIGENT_TIERING"

--- a/config/prod/PsychENCODE-Globus-S3.yaml
+++ b/config/prod/PsychENCODE-Globus-S3.yaml
@@ -17,6 +17,8 @@ parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/dan.lu@sagebase.org'
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
 sceptre_user_data:
   SynapseIDs:
     - "3434599"

--- a/config/prod/TESLA-download-bucket.yaml
+++ b/config/prod/TESLA-download-bucket.yaml
@@ -33,9 +33,9 @@ parameters:
   # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'
   # BucketVersioning: 'Enabled'
   # (Optional) 'Enabled' to enable bucket data life cycle rule, default is 'Disabled'
-  # EnableDataLifeCycle: 'Enabled'
+  EnableDataLifeCycle: 'Enabled'
   # (Optional) S3 bucket objects will transition into this storage class: GLACIER(default), DEEP_ARCHIVE, INTELLIGENT_TIERING, STANDARD_IA, ONEZONE_IA
-  # LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   # (Optional) Number of days until S3 objects are moved to the LifecycleDataStorageClass, default is 30
   # LifecycleDataTransition: '90'
   # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000

--- a/config/prod/VEOIBD-S3-USA.yaml
+++ b/config/prod/VEOIBD-S3-USA.yaml
@@ -17,6 +17,8 @@ parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/dan.lu@sagebase.org'
+  EnableDataLifeCycle: "Enabled"
+  LifecycleDataStorageClass: "INTELLIGENT_TIERING"
 sceptre_user_data:
   SynapseIDs:
     - "3434599"

--- a/config/prod/dian-prod-hm-migration-s3.yaml
+++ b/config/prod/dian-prod-hm-migration-s3.yaml
@@ -39,9 +39,9 @@ parameters:
   # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'
   # BucketVersioning: 'Enabled'
   # (Optional) 'Enabled' to enable bucket data life cycle rule, default is 'Disabled'
-  # EnableDataLifeCycle: 'Enabled'
+  EnableDataLifeCycle: 'Enabled'
   # (Optional) S3 bucket objects will transition into this storage class: GLACIER(default), DEEP_ARCHIVE, INTELLIGENT_TIERING, STANDARD_IA, ONEZONE_IA
-  # LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   # (Optional) Number of days until S3 objects are moved to the LifecycleDataStorageClass, default is 30
   # LifecycleDataTransition: '90'
   # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000

--- a/config/prod/dian-uat-hm-migration-s3.yaml
+++ b/config/prod/dian-uat-hm-migration-s3.yaml
@@ -39,7 +39,7 @@ parameters:
   # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'
   # BucketVersioning: 'Enabled'
   # (Optional) 'Enabled' to enable bucket data life cycle rule, default is 'Disabled'
-  # EnableDataLifeCycle: 'Enabled'
+  EnableDataLifeCycle: 'Enabled'
   # (Optional) S3 bucket objects will transition into this storage class: GLACIER(default), DEEP_ARCHIVE, INTELLIGENT_TIERING, STANDARD_IA, ONEZONE_IA
   # LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   # (Optional) Number of days until S3 objects are moved to the LifecycleDataStorageClass, default is 30

--- a/config/prod/htan-dcc-center-a.yaml
+++ b/config/prod/htan-dcc-center-a.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-center-a"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-center-a"  # must match bucket name in data/s3-synapse-sync-bucket-vars.yaml
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3382314"
     - "3408101"

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-chop"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-chop"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #HTAN DCC
     - "3413795" #service acct

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-dfci"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-dfci"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #HTAN DCC
     - "3413795" #service acct

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-duke"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-duke"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #HTAN DCC
     - "3413795" #service acct

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-hms"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-hms"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #HTAN DCC
     - "3413795" #service acct

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-msk"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-msk"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #htan dcc
     - "3413795" #service acct

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-ohsu"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-ohsu"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #htan dcc
     - "3410328" #htan ohsu

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-pcapp"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-pcapp"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #HTAN DCC
     - "3413795" #service acct

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-stanford"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-stanford"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #HTAN DCC
     - "3413795" #service acct

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tma-tnp"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-tma-tnp"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #htan dcc
     - "3413795" #service acct

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tnp-sardana"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-tnp-sardana"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #htan dcc
     - "3413795" #service acct

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.6.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-vanderbilt"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"
@@ -11,6 +11,8 @@ dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:
   BucketName: "htan-dcc-vanderbilt"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
   SynapseIDs:
     - "3391844" #htan dcc
     - "3413795" #service acct

--- a/config/prod/mep-lincs-s3.yaml
+++ b/config/prod/mep-lincs-s3.yaml
@@ -22,3 +22,5 @@ parameters:
   SynapseUserName: 'larssono'
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required
+  EnableDataLifeCycle: "true"
+  LifecycleDataStorageClass: "INTELLIGENT_TIERING"

--- a/config/prod/nf-syn28545963-s3.yaml
+++ b/config/prod/nf-syn28545963-s3.yaml
@@ -16,6 +16,8 @@ parameters:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/robert.allaway@sagebase.org'
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/sasha.scott@sagebase.org'
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
 sceptre_user_data:
   SynapseIDs:
     - "3342573"

--- a/config/prod/recover-s3-bucket.yaml
+++ b/config/prod/recover-s3-bucket.yaml
@@ -19,6 +19,8 @@ parameters:
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/meghasyam@sagebase.org'
     - 'arn:aws:iam::621233246578:role/EES3-RK-6A32F45B-RECOVER' # QA ARN role for Care Evolution
     - 'arn:aws:iam::659375444835:role/glue-job-role-JobRole-XL4YIFI6POVV' # Recover glue job role access
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
 sceptre_user_data:
   SynapseIDs:
     - "3357179" # Megha's synapse profileID

--- a/config/prod/usage-statistics-S3.yaml
+++ b/config/prod/usage-statistics-S3.yaml
@@ -18,3 +18,5 @@ parameters:
 
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
+  EnableDataLifeCycle: "Enabled"
+  LifecycleDataStorageClass: "INTELLIGENT_TIERING"

--- a/config/prod/veoibd-s3.yaml
+++ b/config/prod/veoibd-s3.yaml
@@ -32,9 +32,9 @@ parameters:
   # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'
   # BucketVersioning: 'Enabled'
   # (Optional) 'Enabled' to enable bucket data life cycle rule, default is 'Disabled'
-  # EnableDataLifeCycle: 'Enabled'
+  EnableDataLifeCycle: "Enabled"
   # (Optional) S3 bucket objects will transition into this storage class: GLACIER(default), DEEP_ARCHIVE, INTELLIGENT_TIERING, STANDARD_IA, ONEZONE_IA
-  # LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+  LifecycleDataStorageClass: "INTELLIGENT_TIERING"
   # (Optional) Number of days until S3 objects are moved to the LifecycleDataStorageClass, default is 30
   # LifecycleDataTransition: '90'
   # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000


### PR DESCRIPTION
This enables intelligent tiering bucket lifecycle for all buckets deployed to the scicomp account.
The goal is to reduce storage costs.

depends on https://github.com/Sage-Bionetworks/s3-synapse-sync/pull/49


