### PR TITLE
Fix typo in url

### DIFF
--- a/config/prod/htan-dcc-center-a.yaml
+++ b/config/prod/htan-dcc-center-a.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-center-a"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-chop"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-dfci"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-duke"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-hms"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-msk"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-ohsu"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-pcapp"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-stanford"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tma-tnp"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tnp-sardana"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -2,7 +2,7 @@
 # work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
 template:
   type: "http"
-  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/v1.7.1/s3-synapse-sync-bucket.j2"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-vanderbilt"
 stack_tags:
   OwnerEmail: "thomas.yu@sagebase.org"


### PR DESCRIPTION
The release for s3-synapse-sync does not contain a `v` in the release tag[1].

[1] https://github.com/Sage-Bionetworks/s3-synapse-sync/tags