### PR TITLE
[IT-3159] Attempt to fix nextflow access to bucket

### DIFF
--- a/config/prod/nf-test-s3.yaml
+++ b/config/prod/nf-test-s3.yaml
@@ -1,0 +1,48 @@
+# Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
+template:
+  path: "nextflow-tower-s3-bucket.j2"
+stack_name: "nf-test-s3"
+stack_tags:
+  OwnerEmail: 'robert.allaway@sagebionetworks.org'
+  CostCenter: "NTAP NF Addendum 4 / 301100"
+parameters:
+  BucketName: "nf-test-s3"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+  SynapseIDs:
+    - "3342573"
+    - "3391844" #HTAN DCC
+    - "3413795" #service acct
+  S3UserARNs:
+    # from nf-syn23664726:
+    - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/robert.allaway@sagebase.org'
+    - 'arn:aws:iam::694704239947:root' ## Nebula Genomics access
+    - 'arn:aws:iam::694704239947:user/giri' ## Nebula Genomics access
+    - 'arn:aws:iam::969434029702:user/audrisc' ##Stanford access (Audris Chiang)
+    - 'arn:aws:iam::728882028485:role/ntap-add5-project-TowerForgeBatchHeadJobRole-X9Y068JVFXHC' ## Sage NF Tower access
+    - 'arn:aws:iam::728882028485:role/ntap-add5-project-TowerForgeBatchWorkJobRole-TYLG8H2QIS7R' ## Sage NF Tower access
+    - 'arn:aws:iam::728882028485:role/ntap-add5-project-TowerForgeServiceRole-1KZP8QDA7AR8P'  ## Sage NF Tower access
+    - 'arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org' ## Sage NF Tower access
+
+    # from s3-synapse-sync:
+    - "arn:aws:iam::292075781285:user/idp-import"
+    - "arn:aws:iam::364787550714:user/abs33@duke.edu-p1b-dheso2"
+    - "arn:aws:iam::364787550714:user/mrl17@duke.edu-p1b-dheso2"
+    - "arn:aws:iam::589138424736:user/svennam"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
+    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
+    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
+    - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
+  DenyDeleteARNs:
+    - "arn:aws:iam::292075781285:user/idp-import"
+    - "arn:aws:iam::364787550714:user/abs33@duke.edu-p1b-dheso2"
+    - "arn:aws:iam::364787550714:user/mrl17@duke.edu-p1b-dheso2"
+    - "arn:aws:iam::589138424736:user/svennam"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
+    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
+    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
+    - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
+  S3AdminARNs:
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/robert.allaway@sagebase.org'
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"

--- a/config/prod/nf-test-s3.yaml
+++ b/config/prod/nf-test-s3.yaml
@@ -17,32 +17,11 @@ parameters:
     # from nf-syn23664726:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/robert.allaway@sagebase.org'
-    - 'arn:aws:iam::694704239947:root' ## Nebula Genomics access
-    - 'arn:aws:iam::694704239947:user/giri' ## Nebula Genomics access
-    - 'arn:aws:iam::969434029702:user/audrisc' ##Stanford access (Audris Chiang)
     - 'arn:aws:iam::728882028485:role/ntap-add5-project-TowerForgeBatchHeadJobRole-X9Y068JVFXHC' ## Sage NF Tower access
     - 'arn:aws:iam::728882028485:role/ntap-add5-project-TowerForgeBatchWorkJobRole-TYLG8H2QIS7R' ## Sage NF Tower access
     - 'arn:aws:iam::728882028485:role/ntap-add5-project-TowerForgeServiceRole-1KZP8QDA7AR8P'  ## Sage NF Tower access
     - 'arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org' ## Sage NF Tower access
-
-    # from s3-synapse-sync:
-    - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::364787550714:user/abs33@duke.edu-p1b-dheso2"
-    - "arn:aws:iam::364787550714:user/mrl17@duke.edu-p1b-dheso2"
-    - "arn:aws:iam::589138424736:user/svennam"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
-    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
-    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
-    - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::364787550714:user/abs33@duke.edu-p1b-dheso2"
-    - "arn:aws:iam::364787550714:user/mrl17@duke.edu-p1b-dheso2"
-    - "arn:aws:iam::589138424736:user/svennam"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
-    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
-    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
-    - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
+    - 'arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/robert.allaway@sagebase.org' ## Sage NF Tower access
   S3AdminARNs:
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/robert.allaway@sagebase.org'
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"

--- a/templates/nextflow-tower-s3-bucket.j2
+++ b/templates/nextflow-tower-s3-bucket.j2
@@ -1,0 +1,191 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: S3Objects
+Description: >-
+  Synapse S3 Custom Storage
+  (https://docs.synapse.org/articles/custom_storage_location.html)
+Parameters:
+  SynapseRootArn:
+    Type: String
+    Description: The Synapse root account ARN
+    Default: "arn:aws:iam::325565585839:root"
+    ConstraintDescription: >-
+      Must be the ARN of the Synapse root account
+  SynapseIDs:
+    Type: CommaDelimitedList
+    Description: >-
+      List of Synapse bucket user or team owners
+    ConstraintDescription: >-
+      List of Synapse user or team IDs separated by commas
+      (i.e. 1111111, 2222222)
+  S3UserARNs:
+    Type: CommaDelimitedList
+    Description: >-
+      (Optional) User ARNs allowed to access S3 Bucket,
+      in addition to provisioning user
+    ConstraintDescription: >-
+      List of ARNs separated by commas (e.g.
+      arn:aws:iam::011223344556:user/jdoe,arn:aws:iam::544332211006:user/rjones)
+  DenyDeleteARNs:
+    Type: CommaDelimitedList
+    Description: >-
+      (Optional) User ARNs NOT allowed to delelte objects in S3 Bucket
+    ConstraintDescription: >-
+      List of ARNs separated by commas (e.g.
+      arn:aws:iam::011223344556:user/jdoe,arn:aws:iam::544332211006:user/rjones)
+  S3AdminARNs:
+    Type: CommaDelimitedList
+    Description: >-
+      (Optional) User ARNs of S3 bucket admins
+    ConstraintDescription: >-
+      List of ARNs separated by commas (e.g.
+      arn:aws:iam::011223344556:user/jdoe,arn:aws:iam::544332211006:user/rjones)
+  BucketName:
+    Type: String
+    Description: (Optional) Name of the created bucket.
+    Default: ""
+  EnableDataLifeCycle:
+    Type: String
+    Description: Enabled to enable bucket lifecycle rule, default is Disabled
+    AllowedValues:
+      - Enabled
+      - Disabled
+    Default: Disabled
+  LifecycleDataTransition:
+    Type: Number
+    Description: Number of days until S3 objects are moved to LifecycleDataStorageClass
+    Default: 30
+    MaxValue: 360
+    MinValue: 1
+  LifecycleDataStorageClass:
+    Type: String
+    Description: S3 bucket objects will transition into this storage class
+    AllowedValues:
+      - DEEP_ARCHIVE
+      - INTELLIGENT_TIERING
+      - STANDARD_IA
+      - ONEZONE_IA
+      - GLACIER
+    Default: GLACIER
+  LifecycleDataExpiration:
+    Type: Number
+    Description: Number of days (from creation) when objects are deleted from S3 and the LifecycleDataStorageClass
+    Default: 365000
+    MaxValue: 365000
+    MinValue: 360
+Conditions:
+  HasBucketName: !Not [!Equals [!Ref BucketName, ""]]
+Resources:
+  S3Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      BucketName: !If [HasBucketName, !Ref BucketName, !Ref 'AWS::NoValue']
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      CorsConfiguration:
+        CorsRules:
+          - Id: SynapseCORSRule
+            AllowedHeaders: ['*']
+            AllowedOrigins: ['*']
+            AllowedMethods: [GET, POST, PUT, HEAD]
+            MaxAge: 3000
+      LifecycleConfiguration:
+        Rules:
+        - Id: DataLifecycleRule
+          Status: !Ref EnableDataLifeCycle
+          ExpirationInDays: !Ref LifecycleDataExpiration
+          Transitions:
+            - TransitionInDays: !Ref LifecycleDataTransition
+              StorageClass: !Ref LifecycleDataStorageClass
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+  S3BucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Properties:
+      Bucket: !Ref S3Bucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: "ReadAccess"
+            Effect: "Allow"
+            Principal:
+              AWS: !Split
+                - ","
+                - !Sub
+                  - "${list},${SynapseRootArn}"
+                  - list: !Join [",",!Ref "S3UserARNs"]
+            Action:
+              - "s3:ListBucket*"
+              - "s3:GetBucketLocation"
+            Resource: !GetAtt S3Bucket.Arn
+          -
+            Sid: "WriteAccess"
+            Effect: "Allow"
+            Principal:
+              AWS: !Split
+                - ","
+                - !Sub
+                  - "${list},${SynapseRootArn}"
+                  - list: !Join [",",!Ref "S3UserARNs"]
+            Action:
+              - "s3:*Object*"
+              - "s3:*MultipartUpload*"
+            Resource: !Sub "${S3Bucket.Arn}/*"
+          -
+            Sid: "DenyDeleteObject"
+            Effect: Deny
+            Principal:
+              AWS: !Ref DenyDeleteARNs
+            Action:
+              - s3:*Delete*
+            Resource: !Sub "${S3Bucket.Arn}/*"
+          -
+            Sid: "AdminBucketObjectAccess"
+            Effect: Allow
+            Principal:
+              AWS: !Ref S3AdminARNs
+            Action:
+              - s3:*
+            Resource: !Sub "${S3Bucket.Arn}/*"
+          -
+            Sid: "AdminBucketAccess"
+            Effect: "Allow"
+            Principal:
+              AWS: !Ref S3AdminARNs
+            Action:
+              - s3:*
+            Resource: !GetAtt S3Bucket.Arn
+
+
+  # Add owner file to the synapse bucket, requires the cloudformation S3 objects macro
+  # https://github.com/Sage-Bionetworks-IT/cfn-s3objects-macro
+  SynapseOwnerFile:
+    Type: AWS::S3::Object
+    DependsOn: "S3BucketPolicy"
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3001
+    Properties:
+      Target:
+        Bucket: !Ref S3Bucket
+        Key: owner.txt
+        ContentType: text
+      Body: !Sub
+        - "${list}"
+        - list: !Join [",",!Ref "SynapseIDs"]
+
+Outputs:
+  BucketName:
+    Description: 'The name of the S3 Bucket'
+    Value: !Ref 'S3Bucket'
+  BucketARN:
+    Description: 'The ARN of the S3 Bucket'
+    Value: !GetAtt 'S3Bucket.Arn'
+  BucketUrl:
+    Description: 'View the S3 Bucket in the AWS Console'
+    Value: !Sub 'https://console.aws.amazon.com/s3/home?region=${AWS::Region}&bucket=${S3Bucket}'


### PR DESCRIPTION
Indications are that nextflow can access the htan-dcc-duke bucket but not the nf-syn* buckets.  Those buckets are setup with different templates.  This is a test to set up a nf-test-s3 bucket using the same template that was used to setup htan-dcc-duke bucket.
