### PR TITLE
Create bucket for HTAN CASI TNP project

### DIFF
--- a/config/prod/htan-dcc-casi-tnp.yaml
+++ b/config/prod/htan-dcc-casi-tnp.yaml
@@ -1,0 +1,40 @@
+# Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html) that will
+# work with the s3-synapse-sync lambda: https://github.com/Sage-Bionetworks/s3-synapse-sync
+template:
+  type: "http"
+  url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
+stack_name: "htan-dcc-casi-tnp"
+stack_tags:
+  OwnerEmail: "thomas.yu@sagebase.org"
+  CostCenter: "HTAN-DFCI / 120100"
+dependencies:
+  - "prod/s3-synapse-sync.yaml"
+parameters:
+  BucketName: "htan-dcc-casi-tnp"
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+  SynapseIDs:
+    - "3391844" #htan dcc
+    - "3413795" #service acct
+  S3UserARNs:
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
+    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
+    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
+    - "arn:aws:iam::292075781285:user/idp-import"
+    - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
+  DenyDeleteARNs:
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
+    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
+    - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
+    - "arn:aws:iam::292075781285:user/idp-import"
+    - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
+  S3AdminARNs:
+    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
+  S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
+  S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"
+
+# Due to circular dependencies, enabling bucket notification must be done after bucket creation
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig.html
+sceptre_user_data:
+  EnableNotificationConfiguration: "false"


### PR DESCRIPTION
Creating a bucket for HTAN's new CASI TNP atlas. The center will be uploading data to Synapse, so we don't intend to enable the s3_synapse_sync function at this stage.