### PR TITLE
Revert "Remove psychencode us-east-1 only restriction"

### DIFF
--- a/config/prod/psychencode-migration-bucket.yaml
+++ b/config/prod/psychencode-migration-bucket.yaml
@@ -12,7 +12,7 @@ parameters:
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  # SameRegionResourceAccessToBucket: 'true'
+  SameRegionResourceAccessToBucket: 'true'
 
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).


### PR DESCRIPTION
NIH approved the region restriction - as long as we have shifted all the data to here

Reverts Sage-Bionetworks/scicomp-provisioner#621