### PR TITLE
Add Region Restriction to psychencode-migration-bucket

### DIFF
--- a/config/prod/psychencode-migration-bucket.yaml
+++ b/config/prod/psychencode-migration-bucket.yaml
@@ -12,7 +12,7 @@ parameters:
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  # SameRegionResourceAccessToBucket: 'true'
+  SameRegionResourceAccessToBucket: 'true'
 
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).


### PR DESCRIPTION
Sage is experiencing $1K-$2K data transfer costs from this bucket.  The change is necessary to prevent excessive ballooning in our AWS bill.
