### PR TITLE
add temporary bucket for Psychencode and CMC migration, with access f…

### DIFF
--- a/config/prod/nda-migration.yaml
+++ b/config/prod/nda-migration.yaml
@@ -1,0 +1,31 @@
+# Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
+template:
+  type: "http"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.4/templates/S3/synapse-external-bucket.j2"
+stack_name: "nda-migration"
+stack_tags:
+  OwnerEmail: 'thomas.yu@sagebase.org'
+  CostCenter: "UMass PECDCC / 106000"
+parameters:
+  # The following parameters are only examples they are not required.
+  # You may omit them if you do not need to override the defaults.
+  # (Optional) true (default) to encrypt bucket, false for no encryption
+  # (Optional) true for read-write bucket, false (default) for read-only bucket
+  AllowWriteBucket: 'true'
+  SameRegionResourceAccessToBucket: 'true'
+
+  # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
+  # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
+  GrantAccess:
+    - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org'
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/william.poehlman@sagebase.org'
+    - 'arn:aws:iam::274274586781:role/nih-dev-power-user'
+    - 'arn:aws:iam::274274586781:role/OPSCrossAccountAdmin'
+  EnableDataLifeCycle: 'Enabled'
+  LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+sceptre_user_data:
+  SynapseIDs:
+    - "3489135" # Rancho - Psychencode migration Synapse team
+    - "3453016" # DPE team
+    - "3357888" # Will


### PR DESCRIPTION
This PR creates a temporary S3 bucket that will be used to store data from the [psychencode migration bucket](https://github.com/Sage-Bionetworks/scicomp-provisioner/blob/b143f2f55639fcc5a689de65f193c899f357083f/config/prod/psychencode-migration-bucket.yaml) and the [CommonMind migration bucket](https://github.com/Sage-Bionetworks/scicomp-provisioner/blob/b143f2f55639fcc5a689de65f193c899f357083f/config/prod/cmc-migration-bucket.yaml), which are currently both being used for indexing on Synapse. This will allow me to transform S3 objects from these temporary buckets into the desired keys, and also isolate the buckets so that we can give NDA direct access to the objects without security concerns. 