### PR TITLE
update CommonMind and Psychencode migration buckets to allow AWS CLI …

### DIFF
--- a/config/prod/cmc-migration-bucket.yaml
+++ b/config/prod/cmc-migration-bucket.yaml
@@ -19,6 +19,7 @@ parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org'
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/william.poehlman@sagebase.org'
   EnableDataLifeCycle: 'Enabled'
   LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
 sceptre_user_data:

--- a/config/prod/psychencode-migration-bucket.yaml
+++ b/config/prod/psychencode-migration-bucket.yaml
@@ -19,6 +19,7 @@ parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org'
+    - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/william.poehlman@sagebase.org'
   EnableDataLifeCycle: 'Enabled'
   LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
 sceptre_user_data:


### PR DESCRIPTION
In order to complete the Psychencode and CommonMind data migrations, I need direct AWS CLI access to these two buckets. This will allow me to transform the object keys and isolate the files into a bucket that NDA can access (see #625 ).