### PR TITLE
update cloudformation template URL on NDA migration bucket

### DIFF
--- a/config/prod/nda-migration.yaml
+++ b/config/prod/nda-migration.yaml
@@ -1,7 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
 template:
   type: "http"
-  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.4/templates/S3/synapse-external-bucket.j2"
+  url: "https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/v0.8.7/templates/S3/synapse-external-bucket.j2"
 stack_name: "nda-migration"
 stack_tags:
   OwnerEmail: 'thomas.yu@sagebase.org'


### PR DESCRIPTION
This PR updates the NDA migration bucket to incorporate changes to the cloudformation template made in [https://github.com/Sage-Bionetworks/aws-infra/pull/409](https://github.com/Sage-Bionetworks/aws-infra/pull/409). 