### PR TITLE
remove region restriction from nda migration bucket

### DIFF
--- a/config/prod/nda-migration.yaml
+++ b/config/prod/nda-migration.yaml
@@ -12,7 +12,7 @@ parameters:
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  SameRegionResourceAccessToBucket: 'true'
+  SameRegionResourceAccessToBucket: 'false'
 
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).


### PR DESCRIPTION
This PR removes the region access restriction for the NDA migration bucket
