### PR TITLE
re-add region restriction to nda migration bucket

### DIFF
--- a/config/prod/nda-migration.yaml
+++ b/config/prod/nda-migration.yaml
@@ -12,7 +12,7 @@ parameters:
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  SameRegionResourceAccessToBucket: 'false'
+  SameRegionResourceAccessToBucket: 'true'
 
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).


### PR DESCRIPTION
This PR adds the region restriction to the NDA migration bucket as a preventative measure to avoid egress. 