### PR TITLE
Offboarding Clarisse Lau from HTAN buckets

### DIFF
--- a/config/prod/htan-dcc-casi-tnp.yaml
+++ b/config/prod/htan-dcc-casi-tnp.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-casi-tnp"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -17,19 +17,17 @@ parameters:
     - "3391844" #htan dcc
     - "3413795" #service acct
   S3UserARNs:
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-center-a.yaml
+++ b/config/prod/htan-dcc-center-a.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-center-a"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -19,18 +19,16 @@ parameters:
     - "3413795"
   S3UserARNs:
     - "arn:aws:iam::070278699608:user/inodb"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::070278699608:user/inodb"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-chop"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -18,18 +18,16 @@ parameters:
     - "3413795" #service acct
   S3UserARNs:
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-dfci"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -18,18 +18,16 @@ parameters:
     - "3413795" #service acct
   S3UserARNs:
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-duke"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -21,7 +21,6 @@ parameters:
     - "arn:aws:iam::364787550714:user/abs33@duke.edu-p1b-dheso2"
     - "arn:aws:iam::364787550714:user/mrl17@duke.edu-p1b-dheso2"
     - "arn:aws:iam::589138424736:user/svennam"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
@@ -30,12 +29,11 @@ parameters:
     - "arn:aws:iam::364787550714:user/abs33@duke.edu-p1b-dheso2"
     - "arn:aws:iam::364787550714:user/mrl17@duke.edu-p1b-dheso2"
     - "arn:aws:iam::589138424736:user/svennam"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-hms"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -19,19 +19,17 @@ parameters:
   S3UserARNs:
     - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-msk"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -20,7 +20,6 @@ parameters:
     - "arn:aws:iam::583643567512:user/jchan"
     - "arn:aws:iam::070278699608:user/inodb"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::583643567512:user/roses3"
     - "arn:aws:iam::583643567512:user/moormana"
     - "arn:aws:iam::583643567512:user/alejandro"
@@ -30,7 +29,6 @@ parameters:
   DenyDeleteARNs:
     - "arn:aws:iam::583643567512:user/jchan"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::583643567512:user/roses3"
     - "arn:aws:iam::583643567512:user/moormana"
     - "arn:aws:iam::583643567512:user/alejandro"
@@ -38,7 +36,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-ohsu"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -20,19 +20,17 @@ parameters:
   S3UserARNs:
     - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-pcapp"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -17,17 +17,15 @@ parameters:
     - "3391844" #HTAN DCC
     - "3413795" #service acct
   S3UserARNs:
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-stanford"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -17,7 +17,6 @@ parameters:
     - "3391844" #HTAN DCC
     - "3413795" #service acct
   S3UserARNs:
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::763613638351:user/stanford-htan-uploader"
@@ -25,7 +24,6 @@ parameters:
     - "arn:aws:iam::763613638351:user/stanford-htan-thomas"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::763613638351:user/stanford-htan-uploader"
@@ -33,7 +31,7 @@ parameters:
     - "arn:aws:iam::763613638351:user/stanford-htan-thomas"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tma-tnp"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -20,7 +20,6 @@ parameters:
     - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::292075781285:user/jmuhlich"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
@@ -28,12 +27,11 @@ parameters:
     - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::292075781285:user/jmuhlich"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-tnp-sardana"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -21,7 +21,6 @@ parameters:
     - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::763613638351:user/stanford-htan-uploader"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
@@ -30,12 +29,11 @@ parameters:
     - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::763613638351:user/stanford-htan-uploader"
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -5,7 +5,7 @@ template:
   url:  "https://raw.githubusercontent.com/Sage-Bionetworks/s3-synapse-sync/1.7.1/s3-synapse-sync-bucket.j2"
 stack_name: "htan-dcc-vanderbilt"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
@@ -17,19 +17,17 @@ parameters:
     - "3391844" #htan dcc
     - "3413795" #service acct
   S3UserARNs:
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
   S3AdminARNs:
-    - "arn:aws:iam::426577889437:user/clarisse.lau"
+    - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"
   S3SynapseSyncFunctionArn: !stack_output_external "s3-synapse-sync::FunctionArn"
   S3SynapseSyncFunctionRoleArn: !stack_output_external "s3-synapse-sync::FunctionRoleArn"

--- a/config/prod/htan-synapse-sync-kms-key.yaml
+++ b/config/prod/htan-synapse-sync-kms-key.yaml
@@ -2,7 +2,7 @@ template:
   path: "htan-synapse-sync-kms-key.yaml"
 stack_name: "htan-synapse-sync-kms-key"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 parameters:
   AdminRoleArns:

--- a/config/prod/s3-synapse-sync.yaml
+++ b/config/prod/s3-synapse-sync.yaml
@@ -3,7 +3,7 @@ template:
   url:  "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/s3-synapse-sync/1.7.2/s3-synapse-sync.yaml"
 stack_name: "s3-synapse-sync"
 stack_tags:
-  OwnerEmail: "thomas.yu@sagebase.org"
+  OwnerEmail: "adam.taylor@sagebase.org"
   CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/htan-synapse-sync-kms-key.yaml"


### PR DESCRIPTION
This PR makes changes to the User, DenyDelete and Admin ARN lists for HTAN S3 buckets.

It forms part of the offboarding for our colleague @clarisse-lau at ISB who has been an admin on these buckets to date.
Adam Taylor will be added as admin to cover this role until a suitable backfill is onboarded.
Tom Yu remains as admin to provide secondary coverage for this role.

The following changes are made
- Clarisse Lau is removed from the `S3AdminARNs` list
- Adam Taylor is added to the `S3AdminARNs` list
- Adam Taylor is removed from the `S3UserARNs` list as now inherits these permissions from `S3AdminARNs` list
- Adam Taylor is removed from the `S3DenyDeleteARNs` list as delete permissions are required in his `S3AdminARNs`role.
- Owner email is updated to Adam Taylor as Sage HTAN PI, replacing @thomasyu888 

Pre-commit successfully passed.