### PR TITLE
Fix deployment of htan2-testing s3 bucket

### DIFF
--- a/config/prod/htan2-testing1.yaml
+++ b/config/prod/htan2-testing1.yaml
@@ -7,17 +7,11 @@ stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
   CostCenter: "HTAN-DFCI / 120100"
 parameters:
-  # The following parameters are only examples they are not required.
-  # You may omit them if you do not need to override the defaults.
-  # (Optional) true (default) to encrypt bucket, false for no encryption
-  # (Optional) true for read-write bucket, false (default) for read-only bucket
-  #BucketName: "htan2_testing1"  # must match bucket name in data/s3-synapse-sync-bucket-vars.yaml
-  AllowWriteBucket: 'true'
-  SameRegionResourceAccessToBucket: 'true'
-  # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
-  # (Optional) Allow accounts, groups, and users to access bucket (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/aditi.gopalan@sagebase.org'
   EnableDataLifeCycle: 'Enabled'
   LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+sceptre_user_data:
+  SynapseIDs:
+    - 3474475  # aditigopalan


### PR DESCRIPTION
* Need to add a synapse ID
* It seems like the `IPAddressRestictionLambda` is failing to deploy. We will need to fix it, removing it from this stack for now.

```
[2024-10-18 16:34:58] - prod/htan2-testing1 IPAddressRestictionLambda
AWS::CloudFormation::Stack CREATE_FAILED Embedded stack
arn:aws:cloudformation:us-east-1:***:stack/htan2-testing1-IPAddressRestictionLambda-1534XYHGZI8V8/cd414320-8d6e-11ef-a975-0affca4facf5
was not successfully created: The following resource(s) failed to create: [RestrictBucketDownloadRegionFunction].
```
