### PR TITLE
Revert "Update deprecated program codes (#646)"

### DIFF
--- a/DeprecatedProgramCodes.json
+++ b/DeprecatedProgramCodes.json
@@ -1,3 +1,16 @@
 [
-  "BMGF-Ki / 30144"
+  "BMGF-Ki / 30144",
+  "Genie-AACR / 312000",
+  "CTF NF Amend 11 / 304002",
+  "CSBC - NCI / 101300",
+  "Model AD-IU / 116000",
+  "NIA AMP-AD CC / 101500",
+  "NTAP NF Addendum 4 / 301100",
+  "HTAN-DFCI / 120100",
+  "NIA AMP-AD CC / 101500",
+  "PECDCC-UMass / 106000",
+  "Psorcast Pscrosis App / 613500",
+  "TREAT AD - Emory / 121100",
+  "Washington Univ - DIAN / 403500",
+  "Multi-Consortia Coordinating Center MC2 Center / 123100"
 ]

--- a/config/prod/AMP-Emory-Bucket.yaml
+++ b/config/prod/AMP-Emory-Bucket.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "AMP-Emory-Bucket"
 stack_tags:
   OwnerEmail: "ampadportal@sagebase.org"
-  CostCenter: "Emory TREAT AD / 121100"
+  CostCenter: "TREAT AD - Emory / 121100"
 parameters:
   # The Sage deparment for this resource
   Department: "SysBio"

--- a/config/prod/PsychENCODE-Globus-S3.yaml
+++ b/config/prod/PsychENCODE-Globus-S3.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "PsychENCODE-Globus-S3"
 stack_tags:
   OwnerEmail: "dan.lu@sagebase.org"
-  CostCenter: "UMass PECDCC / 106000"
+  CostCenter: "PECDCC-UMass / 106000"
 parameters:
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.

--- a/config/prod/aacr-interactome-s3website-new.yaml
+++ b/config/prod/aacr-interactome-s3website-new.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "aacr-interactome-s3website-new"
 stack_tags:
   OwnerEmail: "xindi.guo@sagebase.org"
-  CostCenter: "Genie AACR / 312000"
+  CostCenter: "Genie-AACR / 312000"
 parameters:
   # Domain name for your website (sagebionetworks.org)
   DomainName: "sagebionetworks.org"

--- a/config/prod/amp-mayo-sinai.yaml
+++ b/config/prod/amp-mayo-sinai.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "amp-mayo-sinai"
 stack_tags:
   OwnerEmail: 'william.poehlman@sagebase.org'
-  CostCenter: "IU Model AD / 116000"
+  CostCenter: "Model AD-IU / 116000"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
   Department: "NDR"

--- a/config/prod/dian-prod-hm-migration-s3.yaml
+++ b/config/prod/dian-prod-hm-migration-s3.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "dian-prod-hm-migration-s3"
 stack_tags:
   OwnerEmail: "synapse-service+dian-prod@sagebase.org"
-  CostCenter: "Washington University DIAN / 403500"
+  CostCenter: "Washington Univ - DIAN / 403500"
 sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
   SynapseIDs: ["3425758"]  #synapse-service-dian-prod@synapse.org

--- a/config/prod/dian-uat-hm-migration-s3.yaml
+++ b/config/prod/dian-uat-hm-migration-s3.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "dian-uat-hm-migration-s3"
 stack_tags:
   OwnerEmail: "synapse-service+dian-prod@sagebase.org"
-  CostCenter: "Washington University DIAN / 403500"
+  CostCenter: "Washington Univ - DIAN / 403500"
 sceptre_user_data:
   # (Optional) Synapse IDs for owner.txt file
   SynapseIDs: ["3425757"]  #synapse-service-dian-uat@synapse.org

--- a/config/prod/htan-dcc-casi-tnp.yaml
+++ b/config/prod/htan-dcc-casi-tnp.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-casi-tnp"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-center-a.yaml
+++ b/config/prod/htan-dcc-center-a.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-center-a"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-chop"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-dfci"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-duke"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-hms"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-msk"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-ohsu"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-pcapp"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-stanford"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-tma-tnp"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-tnp-sardana"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-vanderbilt"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-synapse-sync-kms-key.yaml
+++ b/config/prod/htan-synapse-sync-kms-key.yaml
@@ -3,7 +3,7 @@ template:
 stack_name: "htan-synapse-sync-kms-key"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 parameters:
   AdminRoleArns:
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_Developer_d1a84a78c9777596/thomas.yu@sagebase.org"

--- a/config/prod/htan2-testing1.yaml
+++ b/config/prod/htan2-testing1.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-testing1"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket

--- a/config/prod/nf-syn23664726-s3.yaml
+++ b/config/prod/nf-syn23664726-s3.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "nf-syn23664726-s3"
 stack_tags:
   OwnerEmail: 'robert.allaway@sagebionetworks.org'
-  CostCenter: "JHU NTAP / 301100"
+  CostCenter: "NTAP NF Addendum 4 / 301100"
 parameters:
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.

--- a/config/prod/nf-syn28545963-s3.yaml
+++ b/config/prod/nf-syn28545963-s3.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "nf-syn28545963-s3"
 stack_tags:
   OwnerEmail: 'robert.allaway@sagebionetworks.org'
-  CostCenter: "CTF Amendment 11 / 304002"
+  CostCenter: "CTF NF Amend 11 / 304002"
 parameters:
   # The following parameters are only examples they are not required.
   # You may omit them if you do not need to override the defaults.

--- a/config/prod/nf-test-s3.yaml
+++ b/config/prod/nf-test-s3.yaml
@@ -4,7 +4,7 @@ template:
 stack_name: "nf-test-s3"
 stack_tags:
   OwnerEmail: 'robert.allaway@sagebionetworks.org'
-  CostCenter: "JHU NTAP / 301100"
+  CostCenter: "NTAP NF Addendum 4 / 301100"
 parameters:
   BucketName: "nf-test-s3"
   EnableDataLifeCycle: 'Enabled'

--- a/config/prod/s3-synapse-sync.yaml
+++ b/config/prod/s3-synapse-sync.yaml
@@ -4,7 +4,7 @@ template:
 stack_name: "s3-synapse-sync"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "HTAN-DFCI / 120100"
 dependencies:
   - "prod/htan-synapse-sync-kms-key.yaml"
 parameters:


### PR DESCRIPTION
This reverts commit 7f6d5b57ff5f2a73bf36e23117e95b427d84f5a7.

Updating tags fails because AWS will attempt to redeploy templates however the old templates cannot be redeployed since it's stuck using an old version of the cfn-cr-same-region-bucket-download[1] lambda which is failing to deploy.

[1] https://github.com/Sage-Bionetworks-IT/cfn-cr-same-region-bucket-download

