### PR TITLE
remove region restriction from PEC and CMC buckets

### DIFF
--- a/config/prod/cmc-migration-bucket.yaml
+++ b/config/prod/cmc-migration-bucket.yaml
@@ -12,7 +12,7 @@ parameters:
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  SameRegionResourceAccessToBucket: 'true'
+  SameRegionResourceAccessToBucket: 'false'
 
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).

--- a/config/prod/psychencode-migration-bucket.yaml
+++ b/config/prod/psychencode-migration-bucket.yaml
@@ -12,7 +12,7 @@ parameters:
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  SameRegionResourceAccessToBucket: 'true'
+  SameRegionResourceAccessToBucket: 'false'
 
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).


### PR DESCRIPTION
The Psychencode DACC needs to download roughly 2 TB of data from the CMC and PEC project, but they do not have access to AWS. This PR removes the region restriction to allow for the DACC to complete a key final step of the migration from Synapse. Egress cost should be minimal for this download (~$180), and only a few select number of users still have access to these projects on Synapse. 
