### PR TITLE
add AWS transfer restriction to PEC and CMC buckets

### DIFF
--- a/config/prod/cmc-migration-bucket.yaml
+++ b/config/prod/cmc-migration-bucket.yaml
@@ -12,7 +12,7 @@ parameters:
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  SameRegionResourceAccessToBucket: 'false'
+  SameRegionResourceAccessToBucket: 'true'
 
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).

--- a/config/prod/psychencode-migration-bucket.yaml
+++ b/config/prod/psychencode-migration-bucket.yaml
@@ -12,7 +12,7 @@ parameters:
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  SameRegionResourceAccessToBucket: 'false'
+  SameRegionResourceAccessToBucket: 'true'
 
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).


### PR DESCRIPTION
This PR re-introduces the same-region transfer restriction to the CMC and PEC migration buckets that was removed in #658. The PsychEncode DACC has downloaded the files that they need locally, so we should add the restriction back to these buckets to prevent egress. 
