### PR TITLE
add psychencode migration service account to nda-migration bucket

### DIFF
--- a/config/prod/nda-migration.yaml
+++ b/config/prod/nda-migration.yaml
@@ -22,6 +22,7 @@ parameters:
     - 'arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/william.poehlman@sagebase.org'
     - 'arn:aws:iam::274274586781:role/nih-dev-power-user'
     - 'arn:aws:iam::274274586781:role/OPSCrossAccountAdmin'
+    - 'arn:aws:sts::423819316185:assumed-role/ServiceCatalogEndusers/3503713'
   EnableDataLifeCycle: 'Enabled'
   LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
 sceptre_user_data:


### PR DESCRIPTION
The Problem: I need to copy files between two S3 buckets that belong to two different AWS accounts. The first bucket was created using the strides service catalog under the Synapse service account  'synapse-service-psychencode-migration'. The second bucket was created using the scicomp provisioner (https://github.com/wpoehlm/scicomp-provisioner/blob/master/config/prod/nda-migration.yaml). 

The Solution: This PR adds the user ARN for the service account user 'synapse-service-psychencode-migration' to the nda-migration bucket. This will allow me to authenticate the service account directly in the Service Catalog, which will also now have direct access to the 'nda-migration' bucket. 