### PR TITLE
remove region restriction from cmc bucket

### DIFF
--- a/config/prod/cmc-migration-bucket.yaml
+++ b/config/prod/cmc-migration-bucket.yaml
@@ -12,7 +12,7 @@ parameters:
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # (Optional) true for read-write bucket, false (default) for read-only bucket
   AllowWriteBucket: 'true'
-  SameRegionResourceAccessToBucket: 'true'
+  SameRegionResourceAccessToBucket: 'false'
 
   # (Optional) Synapse username (default: ""), required if AllowWriteBucket=true
   # (Optional) Allow accounts, groups, and users to access bucket (default is no access).


### PR DESCRIPTION
The Psychencode/CMC migration team discovered one file that failed to transfer from the CMC bucket previously. To allow them to download this file and complete the migration to NDA, I am removing the region restriction from the CMC bucket temporarily. 