### PR TITLE
HTAN1 Sunset: Revoke bucket permissions for non DCC members

### DIFF
--- a/config/prod/htan-dcc-casi-tnp.yaml
+++ b/config/prod/htan-dcc-casi-tnp.yaml
@@ -28,7 +28,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-casi-tnp.yaml
+++ b/config/prod/htan-dcc-casi-tnp.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-casi-tnp"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-casi-tnp.yaml
+++ b/config/prod/htan-dcc-casi-tnp.yaml
@@ -21,7 +21,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"

--- a/config/prod/htan-dcc-casi-tnp.yaml
+++ b/config/prod/htan-dcc-casi-tnp.yaml
@@ -22,6 +22,7 @@ parameters:
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"

--- a/config/prod/htan-dcc-center-a.yaml
+++ b/config/prod/htan-dcc-center-a.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-center-a"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-center-a.yaml
+++ b/config/prod/htan-dcc-center-a.yaml
@@ -28,7 +28,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/thomas.yu@sagebase.org"

--- a/config/prod/htan-dcc-center-a.yaml
+++ b/config/prod/htan-dcc-center-a.yaml
@@ -23,7 +23,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
   DenyDeleteARNs:
     - "arn:aws:iam::070278699608:user/inodb"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-chop"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -22,6 +22,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -21,7 +21,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/idp-import"

--- a/config/prod/htan-dcc-chop.yaml
+++ b/config/prod/htan-dcc-chop.yaml
@@ -28,7 +28,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -22,6 +22,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -21,7 +21,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/idp-import"

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -28,7 +28,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-dfci.yaml
+++ b/config/prod/htan-dcc-dfci.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-dfci"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -22,6 +22,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::364787550714:user/abs33@duke.edu-p1b-dheso2"

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -18,13 +18,9 @@ parameters:
     - "3413795" #service acct
   S3UserARNs:
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::364787550714:user/abs33@duke.edu-p1b-dheso2"
-    - "arn:aws:iam::364787550714:user/mrl17@duke.edu-p1b-dheso2"
-    - "arn:aws:iam::589138424736:user/svennam"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/idp-import"

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -25,13 +25,9 @@ parameters:
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::364787550714:user/abs33@duke.edu-p1b-dheso2"
-    - "arn:aws:iam::364787550714:user/mrl17@duke.edu-p1b-dheso2"
-    - "arn:aws:iam::589138424736:user/svennam"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-duke.yaml
+++ b/config/prod/htan-dcc-duke.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-duke"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -22,6 +22,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::292075781285:user/idp-import"

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -24,12 +24,10 @@ parameters:
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-hms"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-hms.yaml
+++ b/config/prod/htan-dcc-hms.yaml
@@ -17,12 +17,10 @@ parameters:
     - "3391844" #HTAN DCC
     - "3413795" #service acct
   S3UserARNs:
-    - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::292075781285:user/jmuhlich"

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -25,16 +25,11 @@ parameters:
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:iam::583643567512:user/jchan"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::070278699608:user/inodb"
-    - "arn:aws:iam::583643567512:user/roses3"
-    - "arn:aws:iam::583643567512:user/moormana"
-    - "arn:aws:iam::583643567512:user/alejandro"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -23,9 +23,11 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::583643567512:user/jchan"
     - "arn:aws:iam::292075781285:user/idp-import"
+    - "arn:aws:iam::070278699608:user/inodb"
     - "arn:aws:iam::583643567512:user/roses3"
     - "arn:aws:iam::583643567512:user/moormana"
     - "arn:aws:iam::583643567512:user/alejandro"

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-msk"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-msk.yaml
+++ b/config/prod/htan-dcc-msk.yaml
@@ -17,16 +17,11 @@ parameters:
     - "3391844" #htan dcc
     - "3413795" #service acct
   S3UserARNs:
-    - "arn:aws:iam::583643567512:user/jchan"
     - "arn:aws:iam::070278699608:user/inodb"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::583643567512:user/roses3"
-    - "arn:aws:iam::583643567512:user/moormana"
-    - "arn:aws:iam::583643567512:user/alejandro"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::583643567512:user/jchan"

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -18,12 +18,10 @@ parameters:
     - "3410328" #htan ohsu
     - "3413795" #service acct
   S3UserARNs:
-    - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -25,12 +25,10 @@ parameters:
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-ohsu.yaml
+++ b/config/prod/htan-dcc-ohsu.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-ohsu"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -21,6 +21,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -26,7 +26,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-pcapp"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-pcapp.yaml
+++ b/config/prod/htan-dcc-pcapp.yaml
@@ -20,7 +20,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-stanford"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -19,11 +19,8 @@ parameters:
   S3UserARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
-    - "arn:aws:iam::763613638351:user/stanford-htan-uploader"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::763613638351:user/stanford-htan-thomas"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -26,11 +26,8 @@ parameters:
   DenyDeleteARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
-    - "arn:aws:iam::763613638351:user/stanford-htan-uploader"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::763613638351:user/stanford-htan-thomas"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-stanford.yaml
+++ b/config/prod/htan-dcc-stanford.yaml
@@ -22,6 +22,7 @@ parameters:
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -24,13 +24,10 @@ parameters:
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-tma-tnp"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -17,13 +17,10 @@ parameters:
     - "3391844" #htan dcc
     - "3413795" #service acct
   S3UserARNs:
-    - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::696725769253:user/creason"

--- a/config/prod/htan-dcc-tma-tnp.yaml
+++ b/config/prod/htan-dcc-tma-tnp.yaml
@@ -22,6 +22,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/idp-import"

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -24,14 +24,10 @@ parameters:
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
-    - "arn:aws:iam::696725769253:user/creason"
-    - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::763613638351:user/stanford-htan-uploader"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -22,6 +22,7 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::696725769253:user/creason"
     - "arn:aws:iam::292075781285:user/jmuhlich"

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -17,14 +17,10 @@ parameters:
     - "3391844" #htan dcc
     - "3413795" #service acct
   S3UserARNs:
-    - "arn:aws:iam::696725769253:user/creason"
-    - "arn:aws:iam::292075781285:user/jmuhlich"
     - "arn:aws:iam::292075781285:user/idp-import"
-    - "arn:aws:iam::763613638351:user/stanford-htan-uploader"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::696725769253:user/creason"

--- a/config/prod/htan-dcc-tnp-sardana.yaml
+++ b/config/prod/htan-dcc-tnp-sardana.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-tnp-sardana"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -28,7 +28,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   S3AdminARNs:
     - "arn:aws:sts::526515999252:assumed-role/AWSReservedSSO_S3ExternalCollab_40c062f682e7f3f5/adam.taylor@sagebase.org"

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -6,7 +6,7 @@ template:
 stack_name: "htan-dcc-vanderbilt"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 dependencies:
   - "prod/s3-synapse-sync.yaml"
 parameters:

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -21,7 +21,6 @@ parameters:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
-    - "arn:aws:iam::426577889437:user/bill.clifford"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
   DenyDeleteARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"

--- a/config/prod/htan-dcc-vanderbilt.yaml
+++ b/config/prod/htan-dcc-vanderbilt.yaml
@@ -22,6 +22,7 @@ parameters:
     - "arn:aws:iam::292075781285:user/idp-import"
     - "arn:aws:sts::728882028485:assumed-role/AWSReservedSSO_TowerViewer_fd6aee98ec127705/adam.taylor@sagebase.org"
     - "arn:aws:iam::426577889437:user/darya.pozhidayeva.admin"
+    - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_viewer-plus_96e9ce963c940f21/aditi.gopalan@sagebase.org"
   DenyDeleteARNs:
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchHeadJobRole-17MIZHWBA1TC5"
     - "arn:aws:iam::728882028485:role/htan-project-TowerForgeBatchWorkJobRole-17360PQARGWYU"

--- a/config/prod/htan-synapse-sync-kms-key.yaml
+++ b/config/prod/htan-synapse-sync-kms-key.yaml
@@ -3,7 +3,7 @@ template:
 stack_name: "htan-synapse-sync-kms-key"
 stack_tags:
   OwnerEmail: "adam.taylor@sagebase.org"
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   AdminRoleArns:
     - "arn:aws:sts::055273631518:assumed-role/AWSReservedSSO_Developer_d1a84a78c9777596/thomas.yu@sagebase.org"

--- a/config/prod/htan2-crc-syn63298073.yaml
+++ b/config/prod/htan2-crc-syn63298073.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-crc-syn63298073"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-crc-syn63298073"
   GrantAccess:

--- a/config/prod/htan2-gastric-syn63298051.yaml
+++ b/config/prod/htan2-gastric-syn63298051.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-gastric-syn63298051"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-gastric-syn63298051"
   GrantAccess:

--- a/config/prod/htan2-glioma-syn63298048.yaml
+++ b/config/prod/htan2-glioma-syn63298048.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-glioma-syn63298048"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-glioma-syn63298048"
   GrantAccess:

--- a/config/prod/htan2-lymphoma-syn63298076.yaml
+++ b/config/prod/htan2-lymphoma-syn63298076.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-lymphoma-syn63298076"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-lymphoma-syn63298076"
   GrantAccess:

--- a/config/prod/htan2-myeloma-syn63298063.yaml
+++ b/config/prod/htan2-myeloma-syn63298063.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-myeloma-syn63298063"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-myeloma-syn63298063"
   GrantAccess:

--- a/config/prod/htan2-ovarian-syn63298044.yaml
+++ b/config/prod/htan2-ovarian-syn63298044.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-ovarian-syn63298044"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-ovarian-syn63298044"
   GrantAccess:

--- a/config/prod/htan2-pancreatic-syn63298065.yaml
+++ b/config/prod/htan2-pancreatic-syn63298065.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-pancreatic-syn63298065"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-pancreatic-syn63298065"
   GrantAccess:

--- a/config/prod/htan2-pediatric-syn63298059.yaml
+++ b/config/prod/htan2-pediatric-syn63298059.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-pediatric-syn63298059"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-pediatric-syn63298059"
   GrantAccess:

--- a/config/prod/htan2-prostate-syn63298068.yaml
+++ b/config/prod/htan2-prostate-syn63298068.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-prostate-syn63298068"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-prostate-syn63298068"
   GrantAccess:

--- a/config/prod/htan2-skin-syn63298054.yaml
+++ b/config/prod/htan2-skin-syn63298054.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-skin-syn63298054"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "DFCI HTAN / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   BucketName: "htan2-skin-syn63298054"
   GrantAccess:

--- a/config/prod/htan2-testing1.yaml
+++ b/config/prod/htan2-testing1.yaml
@@ -5,7 +5,7 @@ template:
 stack_name: "htan2-testing1"
 stack_tags:
   OwnerEmail: 'aditi.gopalan@sagebase.org'
-  CostCenter: "HTAN-DFCI / 120100"
+  CostCenter: "DFCI HTAN Renewal / 120100"
 parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket


### PR DESCRIPTION
### Overview
Updates HTAN DCC bucket permissions: adds a new user to S3UserARNs across all HTAN DCC buckets and revokes access for non-essential DCC personnel as part of HTAN 1 sunset.

### Changes

**1. Add aditi.gopalan to S3UserARNs for HTAN DCC buckets and inodb to DenyDeleteARNs for MSK** (`8da4d27`)
- Added `aditi.gopalan@sagebase.org` ARN to `S3UserARNs` in all HTAN DCC bucket configurations:
  - htan-dcc-casi-tnp.yaml
  - htan-dcc-center-a.yaml
  - htan-dcc-chop.yaml
  - htan-dcc-dfci.yaml
  - htan-dcc-duke.yaml
  - htan-dcc-hms.yaml
  - htan-dcc-msk.yaml
  - htan-dcc-ohsu.yaml
  - htan-dcc-pcapp.yaml
  - htan-dcc-stanford.yaml
  - htan-dcc-tma-tnp.yaml
  - htan-dcc-tnp-sardana.yaml
  - htan-dcc-vanderbilt.yaml
  - Added `inodb` user to `DenyDeleteARNs` in `htan-dcc-msk.yaml` to match the pattern used in `htan-dcc-center-a.yaml`

**2. HTAN 1 Sunset: Revoking non-DCC bucket access** (`ad13d1a`)
- Revoked bucket access for non-essential DCC personnel as part of the HTAN 1 sunset process

### Testing
- All modified files passed pre-commit checks (), no changes to those files
